### PR TITLE
fix: custom url scheme is mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Share intent in a native module for Expo (React Native).
 
 ## Installation
 
-Install npm package
+**Install npm package**
 
 ```bash
 yarn add expo-share-intent
@@ -29,7 +29,9 @@ yarn add expo-share-intent
 npm install expo-share-intent
 ```
 
-add expo plugin into your `app.json`
+**Into your `app.json`:**
+
+- add expo plugin
 
 ```json
   "plugins": [
@@ -38,6 +40,14 @@ add expo plugin into your `app.json`
 ```
 
 > by default only text and url sharing is activated
+
+- configure a custom URL scheme
+
+```json
+  "scheme": "my-app"
+```
+
+> More info here : [Linking to your app](https://docs.expo.dev/guides/linking/#linking-to-your-app)
 
 ## Usage
 

--- a/plugin/src/ios/writeIosShareExtensionFiles.ts
+++ b/plugin/src/ios/writeIosShareExtensionFiles.ts
@@ -157,6 +157,11 @@ export function getShareExtensionViewControllerContent(
   console.debug(
     `[expo-share-intent] add ios share extension (scheme:${scheme} appIdentifier:${appIdentifier})`
   );
+  if (!scheme) {
+    throw new Error(
+      "[expo-share-intent] missing custom URL scheme 'expo.scheme' in app.json ! (see https://docs.expo.dev/guides/linking/#linking-to-your-app)"
+    );
+  }
 
   const content = fs.readFileSync(
     path.resolve(__dirname, "./ShareExtensionViewController.swift"),


### PR DESCRIPTION
**Summary**

The share intent does not work without a correct custom url scheme. The build should not succeeded in that case.

**Todo**

- [x] Crash build if project is missconfigured
- [x] Update README.md

**Issue**

- https://github.com/achorein/expo-share-intent/issues/1