### PR TITLE
fix: android intent type null on android 10

### DIFF
--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -65,7 +65,7 @@ class ExpoShareIntentModule : Module() {
         }
 
         fun handleShareIntent(intent: Intent) {
-            if (intent?.type == null) return
+            if (intent.type == null) return
             if (intent.type!!.startsWith("text")) {
                 // text / urls
                 if (intent.action == Intent.ACTION_SEND) {

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -65,6 +65,7 @@ class ExpoShareIntentModule : Module() {
         }
 
         fun handleShareIntent(intent: Intent) {
+            if (intent?.type == null) return
             if (intent.type!!.startsWith("text")) {
                 // text / urls
                 if (intent.action == Intent.ACTION_SEND) {
@@ -78,12 +79,20 @@ class ExpoShareIntentModule : Module() {
                 // files / medias
                 if (intent.action == Intent.ACTION_SEND) {
                     @Suppress("DEPRECATION") // see inline function at the end of the file
-                    val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)!!;
-                    notifyShareIntent(arrayOf(getFileInfo(uri)))
+                    val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM);
+                    if (uri != null) {
+                        notifyShareIntent(arrayOf(getFileInfo(uri)))
+                    } else {
+                        notifyError("empty uri for file sharing: " + intent.action)
+                    }
                 } else if (intent.action == Intent.ACTION_SEND_MULTIPLE) {
                     @Suppress("DEPRECATION") // see inline function at the end of the file
-                    val uris = intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)!!
-                    notifyShareIntent(uris.map { getFileInfo(it) })
+                    val uris = intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
+                    if (uris != null) {
+                        notifyShareIntent(uris.map { getFileInfo(it) })
+                    } else {
+                        notifyError("empty uris array for file sharing: " + intent.action)
+                    }
                 } else {
                     notifyError("Invalid action for file sharing: " + intent.action)
                 }


### PR DESCRIPTION
**Summary**

Fix the error occurring on device Android 10 (SDK 29) :

```java
Exception java.lang.NullPointerException:
  at expo.modules.shareintent.ExpoShareIntentModule$Companion.handleShareIntent (ExpoShareIntentModule.kt:64)
  at expo.modules.shareintent.ExpoShareIntentModule$definition$lambda$4$$inlined$OnNewIntent$1.invoke (ModuleDefinitionBuilder.kt:144)
  at expo.modules.shareintent.ExpoShareIntentModule$definition$lambda$4$$inlined$OnNewIntent$1.invoke (ModuleDefinitionBuilder.kt:117)
  at expo.modules.kotlin.events.EventListenerWithPayload.call (EventListener.kt:25)
  at expo.modules.kotlin.ModuleHolder.post (ModuleHolder.kt:100)
  at expo.modules.kotlin.ModuleRegistry.post (ModuleRegistry.kt:94)
  at expo.modules.kotlin.AppContext.onNewIntent$expo_modules_core_release (AppContext.kt:350)
  at expo.modules.kotlin.ReactLifecycleDelegate.onNewIntent (ReactLifecycleDelegate.kt:37)
  at com.facebook.react.bridge.ReactContext.onNewIntent (ReactContext.java:322)
  at com.facebook.react.ReactInstanceManager.onNewIntent (ReactInstanceManager.java:535)
  at com.facebook.react.ReactActivityDelegate.onNewIntent (ReactActivityDelegate.java:183)
  at expo.modules.ReactActivityDelegateWrapper.onNewIntent (ReactActivityDelegateWrapper.kt:254)
  at com.facebook.react.ReactActivity.onNewIntent (ReactActivity.java:102)
  at android.app.Activity.performNewIntent (Activity.java:7971)
  at android.app.Instrumentation.callActivityOnNewIntent (Instrumentation.java:1407)
  at android.app.Instrumentation.callActivityOnNewIntent (Instrumentation.java:1420)
  at android.app.ActivityThread.deliverNewIntents (ActivityThread.java:3770)
  at android.app.ActivityThread.handleNewIntent (ActivityThread.java:3782)
  at android.app.servertransaction.NewIntentItem.execute (NewIntentItem.java:53)
  at android.app.servertransaction.TransactionExecutor.executeCallbacks (TransactionExecutor.java:135)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:95)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2220)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loop (Looper.java:237)
  at android.app.ActivityThread.main (ActivityThread.java:8016)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1076)
```

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
- [ ] Update README.md
-->

<!-- If you have a Notion Ticket / GitHub Issue -->

**Issue**

<!-- If you have a GitHub Issue -->