### PR TITLE
fix: android OnNewIntent not fired on first app launch

### DIFF
--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -100,22 +100,18 @@ class ExpoShareIntentModule : Module() {
         }
     }
 
-    // Each module class must implement the definition function. The definition consists of components
-    // that describes the module's functionality and behavior.
-    // See https://docs.expo.dev/modules/module-api for more details about available components.
+    // See https://docs.expo.dev/modules/module-api
     override fun definition() = ModuleDefinition {
-        // Sets the name of the module that JavaScript code will use to refer to the module. Takes a string as an argument.
-        // Can be inferred from module's class name, but it's recommended to set it explicitly for clarity.
-        // The module will be accessible from `requireNativeModule('ExpoShareIntentModule')` in JavaScript.
         Name("ExpoShareIntentModule")
 
-        // Defines event names that the module can send to JavaScript.
         Events("onChange", "onError")
 
-        // Defines a JavaScript function that always returns a Promise and whose native code
-        // is by default dispatched on the different thread than the JavaScript runtime runs on.
         AsyncFunction("getShareIntent") { _: String ->
-            // nothing to do for Android
+            // get the Intent from onCreate activity (app not running in background)
+            if (ExpoShareIntentSingleton.intent?.type != null) {
+                handleShareIntent(ExpoShareIntentSingleton.intent!!);
+                ExpoShareIntentSingleton.intent = null
+            }
         }
 
         OnNewIntent {

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentPackage.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentPackage.kt
@@ -1,0 +1,11 @@
+package expo.modules.shareintent
+
+import android.content.Context
+import expo.modules.core.interfaces.Package
+import expo.modules.core.interfaces.ReactActivityLifecycleListener
+
+class ExpoShareIntentPackage : Package {
+  override fun createReactActivityLifecycleListeners(activityContext: Context): List<ReactActivityLifecycleListener> {
+    return listOf(ExpoShareIntentReactActivityLifecycleListener(activityContext))
+  }
+}

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentReactActivityLifecycleListener.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentReactActivityLifecycleListener.kt
@@ -1,0 +1,18 @@
+package expo.modules.shareintent
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ShortcutManager
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import expo.modules.core.interfaces.ReactActivityLifecycleListener
+
+
+class ExpoShareIntentReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
+
+    override fun onCreate(activity: Activity?, savedInstanceState: Bundle?) {
+        ExpoShareIntentSingleton.intent = activity?.intent
+    }
+}

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentSingleton.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentSingleton.kt
@@ -1,0 +1,14 @@
+package expo.modules.shareintent
+
+import android.content.Intent
+import expo.modules.core.interfaces.SingletonModule
+
+object ExpoShareIntentSingleton : SingletonModule {
+
+  override fun getName(): String {
+    return "ExpoShareIntent"
+  }
+
+  // member to store the initial launch intent
+  var intent: Intent? = null
+}

--- a/src/ExpoShareIntentModule.ts
+++ b/src/ExpoShareIntentModule.ts
@@ -14,7 +14,7 @@ import { ChangeEventPayload } from "./ExpoShareIntentModule.types";
 const ExpoShareIntentModule = requireNativeModule("ExpoShareIntentModule");
 export default ExpoShareIntentModule;
 
-export function getShareIntent(url: string): string {
+export function getShareIntent(url = ""): string {
   return ExpoShareIntentModule.getShareIntent(url);
 }
 

--- a/src/useShareIntent.tsx
+++ b/src/useShareIntent.tsx
@@ -1,7 +1,7 @@
 import Constants from "expo-constants";
 import { useURL } from "expo-linking";
 import { useEffect, useRef, useState } from "react";
-import { AppState } from "react-native";
+import { AppState, Platform } from "react-native";
 
 import {
   addChangeListener,
@@ -58,9 +58,11 @@ export default function useShareIntent(
    * Call native module on universal linking url change
    */
   const refreshShareIntent = () => {
-    // iOS only
     if (url?.startsWith(`${Constants.expoConfig?.scheme}://dataUrl`)) {
+      // iOS only
       getShareIntent(url);
+    } else if (Platform.OS === "android") {
+      getShareIntent();
     }
   };
 


### PR DESCRIPTION
**Summary**

In case the app was not opened before (not in a background state), the [Activity lifecycle listeners](https://docs.expo.dev/modules/android-lifecycle-listeners/#activity-lifecycle-listeners) `OnNewIntent` is not fired and share info cannot be retrieve on the application

**Todo**

- [x] Implement `ReactActivityLifecycleListener` to save original intent from native lifecycle
- [x] Handle `getShareIntent` in Android to force triggering the event

**Issue**

#9