### PR TITLE
feat: add share intent state management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,22 +39,17 @@ android.iml
 android/app/libs
 android/keystores/debug.keystore
 
-# Cocoapods
-#
-example/ios/Pods
-
-# Ruby
-example/vendor/
-
 # node.js
 #
-node_modules/
+node_modules
 npm-debug.log
 yarn-debug.log
 yarn-error.log
 
 # Expo
-.expo/*
+example/*/.expo
+example/*/android
+example/*/ios
 
 # Custom
 .env

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -43,7 +43,11 @@ class ExpoShareIntentModule : Module() {
         private var instance: ExpoShareIntentModule? = null
 
         private fun notifyShareIntent(value: Any) {
+            notifyState("pending")
             instance!!.sendEvent("onChange", mapOf("value" to value))
+        }
+        private fun notifyState(state: String) {
+            instance!!.sendEvent("onStateChange", mapOf("value" to state))
         }
         private fun notifyError(message: String) {
             instance!!.sendEvent("onError", mapOf("value" to message))
@@ -104,10 +108,11 @@ class ExpoShareIntentModule : Module() {
     override fun definition() = ModuleDefinition {
         Name("ExpoShareIntentModule")
 
-        Events("onChange", "onError")
+        Events("onChange", "onStateChange", "onError")
 
         AsyncFunction("getShareIntent") { _: String ->
             // get the Intent from onCreate activity (app not running in background)
+            ExpoShareIntentSingleton.isPending = false
             if (ExpoShareIntentSingleton.intent?.type != null) {
                 handleShareIntent(ExpoShareIntentSingleton.intent!!);
                 ExpoShareIntentSingleton.intent = null
@@ -116,6 +121,10 @@ class ExpoShareIntentModule : Module() {
 
         Function("clearShareIntent") { _: String ->
             ExpoShareIntentSingleton.intent = null
+        }
+
+        Function("hasShareIntent") { _: String ->
+            ExpoShareIntentSingleton.isPending
         }
 
         OnNewIntent {

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentReactActivityLifecycleListener.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentReactActivityLifecycleListener.kt
@@ -14,5 +14,6 @@ class ExpoShareIntentReactActivityLifecycleListener(activityContext: Context) : 
 
     override fun onCreate(activity: Activity?, savedInstanceState: Bundle?) {
         ExpoShareIntentSingleton.intent = activity?.intent
+        ExpoShareIntentSingleton.isPending = activity?.intent?.type != null
     }
 }

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentSingleton.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentSingleton.kt
@@ -9,6 +9,7 @@ object ExpoShareIntentSingleton : SingletonModule {
     return "ExpoShareIntent"
   }
 
-  // member to store the initial launch intent
+  // members to store the initial launch intent
   var intent: Intent? = null
+  var isPending: Boolean = false
 }

--- a/ios/ExpoShareIntentModule.swift
+++ b/ios/ExpoShareIntentModule.swift
@@ -18,7 +18,7 @@ public class ExpoShareIntentModule: Module {
     // The module will be accessible from `requireNativeModule('ExpoShareIntentModule')` in JavaScript.
     Name("ExpoShareIntentModule")
 
-    Events("onChange", "onError")
+    Events("onChange", "onStateChange", "onError")
 
     // Defines a JavaScript function that always returns a Promise and whose native code
     // is by default dispatched on the different thread than the JavaScript runtime runs on.
@@ -36,6 +36,11 @@ public class ExpoShareIntentModule: Module {
         let userDefaults = UserDefaults(suiteName: "group.\(Bundle.main.bundleIdentifier!)")
         userDefaults?.set(nil, forKey: sharedKey)
         userDefaults?.synchronize()
+    }
+
+    Function("hasShareIntent") { (key: String) in
+        // for Android only
+        return false
     }
   }
 

--- a/src/ExpoShareIntentModule.ts
+++ b/src/ExpoShareIntentModule.ts
@@ -6,7 +6,10 @@ import {
 } from "expo-modules-core";
 
 import { SHARE_EXTENSION_KEY } from ".";
-import { ChangeEventPayload } from "./ExpoShareIntentModule.types";
+import {
+  ChangeEventPayload,
+  StateEventPayload,
+} from "./ExpoShareIntentModule.types";
 
 // Import the native module. it will be resolved on native platforms to ExpoShareIntentModule.ts
 // It loads the native module object from the JSI or falls back to
@@ -20,6 +23,10 @@ export function getShareIntent(url = ""): string {
 
 export function clearShareIntent(key = SHARE_EXTENSION_KEY): string {
   return ExpoShareIntentModule.clearShareIntent(key);
+}
+
+export function hasShareIntent(key = SHARE_EXTENSION_KEY): boolean {
+  return ExpoShareIntentModule.hasShareIntent(key);
 }
 
 const emitter = new EventEmitter(
@@ -36,4 +43,10 @@ export function addChangeListener(
   listener: (event: ChangeEventPayload) => void,
 ): Subscription {
   return emitter.addListener<ChangeEventPayload>("onChange", listener);
+}
+
+export function addStateListener(
+  listener: (event: StateEventPayload) => void,
+): Subscription {
+  return emitter.addListener<StateEventPayload>("onStateChange", listener);
 }

--- a/src/ExpoShareIntentModule.types.ts
+++ b/src/ExpoShareIntentModule.types.ts
@@ -2,9 +2,14 @@ export type ChangeEventPayload = {
   value: string;
 };
 
+export type StateEventPayload = {
+  value: "pending" | "none";
+};
+
 export type ShareIntentOptions = {
   debug?: boolean;
   resetOnBackground?: boolean;
+  onResetShareIntent?: () => void;
 };
 
 export type ShareIntent = {

--- a/src/ShareIntentProvider.tsx
+++ b/src/ShareIntentProvider.tsx
@@ -4,6 +4,7 @@ import { ShareIntent, ShareIntentOptions } from "./ExpoShareIntentModule.types";
 import useShareIntent, { SHAREINTENT_DEFAULTVALUE } from "./useShareIntent";
 
 type ShareIntentContextState = {
+  isReady: boolean;
   hasShareIntent: boolean;
   shareIntent: ShareIntent;
   resetShareIntent: () => void;
@@ -11,6 +12,7 @@ type ShareIntentContextState = {
 };
 
 const ShareIntentContext = React.createContext<ShareIntentContextState>({
+  isReady: false,
   hasShareIntent: false,
   shareIntent: SHAREINTENT_DEFAULTVALUE,
   resetShareIntent: () => {},
@@ -30,12 +32,13 @@ export function ShareIntentProvider({
   options?: ShareIntentOptions;
   children: any;
 }) {
-  const { hasShareIntent, shareIntent, resetShareIntent, error } =
+  const { isReady, hasShareIntent, shareIntent, resetShareIntent, error } =
     useShareIntent(options);
 
   return (
     <ShareIntentContext.Provider
       value={{
+        isReady,
         hasShareIntent,
         shareIntent,
         resetShareIntent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,11 @@ export { ShareIntent } from "./ExpoShareIntentModule.types";
 
 export const SHARE_EXTENSION_KEY = `${Constants.expoConfig?.scheme}ShareKey`;
 export {
+  hasShareIntent,
   getShareIntent,
   clearShareIntent,
   addChangeListener,
+  addStateListener,
   addErrorListener,
 } from "./ExpoShareIntentModule";
 

--- a/src/useShareIntent.tsx
+++ b/src/useShareIntent.tsx
@@ -63,11 +63,15 @@ export default function useShareIntent(
     SHAREINTENT_DEFAULTVALUE,
   );
   const [error, setError] = useState<string | null>(null);
+  const [isReady, setIsReady] = useState(false);
 
   const resetShareIntent = () => {
     setError(null);
     clearShareIntent();
-    setSharedIntent(SHAREINTENT_DEFAULTVALUE);
+    if (shareIntent?.text || shareIntent?.files) {
+      setSharedIntent(SHAREINTENT_DEFAULTVALUE);
+      options.onResetShareIntent?.();
+    }
   };
 
   /**
@@ -115,7 +119,7 @@ export default function useShareIntent(
     return () => {
       subscription.remove();
     };
-  }, [url]);
+  }, [url, shareIntent]);
 
   /**
    * Detect Native Module response
@@ -134,6 +138,7 @@ export default function useShareIntent(
       options.debug && console.debug("useShareIntent[error]", event?.value);
       setError(event?.value);
     });
+    setIsReady(true);
     return () => {
       changeSubscription.remove();
       errorSubscription.remove();
@@ -141,6 +146,7 @@ export default function useShareIntent(
   }, []);
 
   return {
+    isReady,
     hasShareIntent: !!(shareIntent?.text || shareIntent?.files),
     shareIntent,
     resetShareIntent,


### PR DESCRIPTION
**Summary**

```ts
import { ShareIntentProvider, useShareIntentContext, hasShareIntent, addStateListener } from "expo-share-intent";
```

**Todo**

- [x] add `onResetShareIntent` callback in options to handle hook shareintent state change
```ts
        onResetShareIntent: () => navigationRef.current?.navigate("Home"),
```
- [x] Android: add synchrone function `hasShareIntent()` to know if a pending intent is ready
- [x] Android: new state management for pending intent
```ts
    const shareIntentEventSubscription = addStateListener((event) => {
      if (event.value === "pending") {
         // Go to screen with useShareIntent hook
      }
    });
```

**Test**
- [x] Android : new app launch (not in background)
- [x] Android : app in background
- [x] iOS : new app launch (not in background)
- [x] iOS : app in background