### PR TITLE
feat: Add ShareIntentProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ For the moment this package need a post-install script
 
 - copy the [xcode patch](https://github.com/achorein/expo-share-intent/blob/main/example/basic/patches/xcode%2B3.0.1.patch) in you `patches` project directory (like example)
 - add post-install script
+
 ```json
   "scripts": {
     ...
     "postinstall": "patch-package"
   },
 ```
+
 - add `patch-package` for auto patching
+
 ```bash
 yarn add patch-package
 ```
@@ -86,15 +89,41 @@ expo run:android
 
 #### Use the hook in your App
 
-```ts
-import { useShareIntent } from "expo-share-intent";
-```
+Make sure to use the hook in your main `App.tsx` component before any other Provider :
 
 ```ts
-const { hasShareIntent, shareIntent, resetShareIntent } = useShareIntent();
+import { useShareIntent } from "expo-share-intent";
+
+const { hasShareIntent, shareIntent, resetShareIntent, error } =
+  useShareIntent();
 ```
 
 See [App.tsx ](https://github.com/achorein/expo-share-intent/blob/main/example/basic/App.tsx) for more details
+
+#### Use the Provider in your App
+
+When dealing with multiple screens and providers your may use `ShareIntentProvider` and it's specific hook `useShareIntentContext`. Must be in your top component (`App.tsx`) before any other Provider :
+
+```tsx
+import { ShareIntentProvider, useShareIntentContext } from "expo-share-intent";
+
+
+const Home = () => {
+  const { hasShareIntent, shareIntent, resetShareIntent, error } = useShareIntentContext();
+  return ...
+}
+
+export default const App = () => {
+  return (
+    <ShareIntentProvider>
+      <ThirdPartyExtraProvider>
+        <Home />
+      </ThirdPartyExtraProvider>
+    </ShareIntentProvider>
+  )
+}
+
+```
 
 #### Configure Content Types in `app.json`
 

--- a/src/ShareIntentProvider.tsx
+++ b/src/ShareIntentProvider.tsx
@@ -1,0 +1,48 @@
+import React, { useContext } from "react";
+
+import { ShareIntent, ShareIntentOptions } from "./ExpoShareIntentModule.types";
+import useShareIntent, { SHAREINTENT_DEFAULTVALUE } from "./useShareIntent";
+
+type ShareIntentContextState = {
+  hasShareIntent: boolean;
+  shareIntent: ShareIntent;
+  resetShareIntent: () => void;
+  error: string | null;
+};
+
+const ShareIntentContext = React.createContext<ShareIntentContextState>({
+  hasShareIntent: false,
+  shareIntent: SHAREINTENT_DEFAULTVALUE,
+  resetShareIntent: () => {},
+  error: null,
+});
+
+export const ShareIntentContextConsumer = ShareIntentContext.Consumer;
+
+export function useShareIntentContext() {
+  return useContext(ShareIntentContext);
+}
+
+export function ShareIntentProvider({
+  options,
+  children,
+}: {
+  options?: ShareIntentOptions;
+  children: any;
+}) {
+  const { hasShareIntent, shareIntent, resetShareIntent, error } =
+    useShareIntent(options);
+
+  return (
+    <ShareIntentContext.Provider
+      value={{
+        hasShareIntent,
+        shareIntent,
+        resetShareIntent,
+        error,
+      }}
+    >
+      {children}
+    </ShareIntentContext.Provider>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,7 @@ export {
 } from "./ExpoShareIntentModule";
 
 export { default as useShareIntent } from "./useShareIntent";
+export {
+  ShareIntentProvider,
+  useShareIntentContext,
+} from "./ShareIntentProvider";


### PR DESCRIPTION
**Summary**

Add a context provider to persist sharing intent over multiple screen or when dealing with multiple third party provider.

**Issue**

https://github.com/achorein/expo-share-intent/issues/15