### PR TITLE
fix: add incompatibility checker on prebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Allow sharing **URL, text, images, videos and files** to your **iOS** and **Android** app, using a simple native module for Expo (React Native)
 
+## Versioning
+
+Ensure you use versions that work together!
+
 | Expo       | Supported `expo-share-intent` version |
 | ---------- | ------------------------------------- |
 | **SDK 50** | 1.0+                                  |

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "wrap-ansi": "^7"
   },
   "peerDependencies": {
-    "expo": ">=50.0.0",
+    "expo": "^50",
     "expo-constants": ">=14.4.2",
     "expo-linking": ">=6.2.2",
     "react": "*",

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -12,6 +12,7 @@ import { withAppEntitlements } from "./ios/withIosAppEntitlements";
 import { withShareExtensionConfig } from "./ios/withIosShareExtensionConfig";
 import { withShareExtensionXcodeTarget } from "./ios/withIosShareExtensionXcodeTarget";
 import { Parameters } from "./types";
+import { withCompatibilityChecker } from "./withCompatibilityChecker";
 
 const pkg: { name: string; version?: string } = {
   name: "expo-share-intent",
@@ -28,6 +29,7 @@ const withShareMenu: ConfigPlugin<Parameters> = createRunOncePlugin(
       // Android
       () => withAndroidIntentFilters(config, params),
       () => withAndroidMainActivityAttributes(config, params),
+      withCompatibilityChecker,
     ]);
   },
   pkg.name,

--- a/plugin/src/withCompatibilityChecker.ts
+++ b/plugin/src/withCompatibilityChecker.ts
@@ -1,0 +1,22 @@
+import { ConfigPlugin, WarningAggregator } from "@expo/config-plugins";
+
+import packageInfo from "../../package.json";
+
+let alreayCheck = false;
+
+export const withCompatibilityChecker: ConfigPlugin = (config) => {
+  if (alreayCheck) return config;
+  alreayCheck = true;
+  if (
+    !config.sdkVersion?.includes(
+      packageInfo.peerDependencies.expo.replace("^", ""),
+    )
+  ) {
+    WarningAggregator.addWarningAndroid(
+      packageInfo.name,
+      `your Expo SDK version does not match requirements! v${packageInfo.version} needs ${packageInfo.peerDependencies.expo}, found ${config.sdkVersion}. Please refer to the compatibility table.`,
+      `${packageInfo.homepage}#versioning`,
+    );
+  }
+  return config;
+};

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "expo-module-scripts/tsconfig.plugin",
   "compilerOptions": {
     "outDir": "build",
-    "rootDir": "src"
+    "rootDir": "src",
+    "resolveJsonModule": true
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]


### PR DESCRIPTION
**Summary**

Simply add a warning message for incompatibility with expo SDK

```bach
$ expo prebuild --no-install
» android: expo-share-intent: your Expo SDK version does not match requirements ! v1.1.1 needs ^50, found 49.0.0. Please refer to the compatibility table. https://github.com/achorein/expo-share-intent/#versioning
```

**Todo**

- [x] Add version checker in the plugin
- [x] Update README.md
