### PR TITLE
fix: Check compatibilty with scheme and CFBundleURLSchemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,28 @@ NB: don't commit your ios/ and android/ folder, rebuild it before EAS build.
 
 > If you want to open your application in expo go with this package your can **disable** the native module call with `useShareIntent({ disabled: true })`. Allowing to speed test other features on your app without share intent.
 
+### Google Signin and CFBundleURLSchemes
+
+When using `@react-native-google-signin/google-signin` you need to configure a custom scheme in your app.json to handle google signin fallback. By doing this, the original app scheme is deleted and must be manually reassigned :
+
+```json
+ "scheme": "exposhareintentexample",
+ "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "expo.modules.exposhareintent.example",
+      "infoPlist": {
+        "CFBundleURLTypes": [
+          {
+            "CFBundleURLSchemes": [
+              "com.googleusercontent.apps.xxxxxxxx-xxxxxxxxx",
+              "exposhareintentexample"
+            ]
+          }
+        ]
+      }
+    },
+```
+
 ### Custom view ?
 
 At the moment, this project does not support iOS custom view (native view in share intent context).

--- a/plugin/src/withCompatibilityChecker.ts
+++ b/plugin/src/withCompatibilityChecker.ts
@@ -18,5 +18,19 @@ export const withCompatibilityChecker: ConfigPlugin = (config) => {
       `${packageInfo.homepage}#versioning`,
     );
   }
+  if (!config.scheme) {
+    throw new Error(
+      `[${packageInfo.name}] Incompatibility found, you must configure a scheme into you app.json file ! (see https://docs.expo.dev/guides/linking/#linking-to-your-app)`,
+    );
+  }
+  const CFBundleURLSchemes = config.ios?.infoPlist?.CFBundleURLTypes?.find(
+    (type: any) => type.CFBundleURLSchemes,
+  )?.CFBundleURLSchemes;
+  if (CFBundleURLSchemes && !CFBundleURLSchemes.includes(config.scheme)) {
+    throw new Error(
+      `[${packageInfo.name}] Incompatibility found, when you override CFBundleURLSchemes you have to manually add the application scheme ! (ios.infoPlist.CFBundleURLTypes.CFBundleURLSchemes: ${JSON.stringify([...CFBundleURLSchemes, config.scheme])})`,
+    );
+  }
+
   return config;
 };


### PR DESCRIPTION
**Summary**

When using `@react-native-google-signin/google-signin` we need to configure a custom scheme in our app.json to handle google signin fallback. By doing this, the original app scheme is deleted and must be manually reassigned.
This PR add compatibilty check to drive new comers

**Todo**

- [x] Check `expo.scheme` is not missing
- [x] Check `expo.ios.infoPlist.CFBundleURLTypes.CFBundleURLSchemes` compatibility
- [x] Update README.md

**Issue**

- https://github.com/achorein/expo-share-intent-demo/issues/19
- https://github.com/achorein/expo-share-intent/issues/35

Thanks to @magnum6actual ! 🙏 