### PR TITLE
feat: retreive file mimeType from iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ export default const App = () => {
 const { shareIntent } = useShareIntent();
 ```
 
-| attribute            | description                                           | example                                                                                                                                                                                                              |
-| -------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `shareIntent.text`   | raw text from text/weburl (ios) and text/\* (android) | "`some text`", "`http://example.com`", "`Hey, Click on my link : http://example.com/nickname`"                                                                                                                       |
-| `shareIntent.webUrl` | link extracted from raw text                          | `null`, "`http://example.com`", "`http://example.com/nickname`"                                                                                                                                                      |
-| `shareIntent.files`  | image / movies / audio / files with path and type     | ios: `[{ path: "file:///local/path/filename.jpg", type: "media", fileName: "originalFilename.jpg" }]`<br/>android: `[{ path: "file:///local/path/filename", type: "image/jpeg", fileName: "originalFilename.jpg" }]` |
+| attribute            | description                                           | example                                                                                               |
+| -------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `shareIntent.text`   | raw text from text/weburl (ios) and text/\* (android) | "`some text`", "`http://example.com`", "`Hey, Click on my link : http://example.com/nickname`"        |
+| `shareIntent.webUrl` | link extracted from raw text                          | `null`, "`http://example.com`", "`http://example.com/nickname`"                                       |
+| `shareIntent.files`  | image / movies / audio / files with path and type     | `[{ path: "file:///local/path/filename", mimeType: "image/jpeg", fileName: "originalFilename.jpg" }]` |
 
 #### Customize Content Types in `app.json`
 

--- a/ios/ExpoShareIntentModule.swift
+++ b/ios/ExpoShareIntentModule.swift
@@ -62,11 +62,11 @@ public class ExpoShareIntentModule: Module {
                         if let path = getAbsolutePath(for: $0.path) {
                             if ($0.type == .video && $0.thumbnail != nil) {
                                 let thumbnail = getAbsolutePath(for: $0.thumbnail!)
-                                return SharedMediaFile.init(path: path, thumbnail: thumbnail, fileName: $0.fileName, duration: $0.duration, type: $0.type)
+                                return SharedMediaFile.init(path: path, thumbnail: thumbnail, fileName: $0.fileName, duration: $0.duration, mimeType: $0.mimeType, type: $0.type)
                             } else if ($0.type == .video && $0.thumbnail == nil) {
-                                return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, duration: $0.duration, type: $0.type)
+                                return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, duration: $0.duration, mimeType: $0.mimeType, type: $0.type)
                             }
-                            return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, duration: $0.duration, type: $0.type)
+                            return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, duration: $0.duration, mimeType: $0.mimeType, type: $0.type)
                         }
                         return nil
                     }
@@ -82,7 +82,7 @@ public class ExpoShareIntentModule: Module {
                     let sharedArray = decode(data: json)
                     let sharedMediaFiles: [SharedMediaFile] = sharedArray.compactMap{
                         if let path = getAbsolutePath(for: $0.path) {
-                            return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, duration: nil, type: $0.type)
+                            return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, duration: nil, mimeType: $0.mimeType, type: $0.type)
                         }
                         return nil
                     }
@@ -168,17 +168,19 @@ public class ExpoShareIntentModule: Module {
   }
 
   class SharedMediaFile: Codable {
-    var path: String;
+    var path: String; // can be image, video or url path
     var thumbnail: String?; // video thumbnail
-    var fileName: String?; // video thumbnail
+    var fileName: String; // video thumbnail
     var duration: Double?; // video duration in milliseconds
+    var mimeType: String;
     var type: SharedMediaType;
 
-    init(path: String, thumbnail: String?, fileName: String?, duration: Double?, type: SharedMediaType) {
+    init(path: String, thumbnail: String?, fileName: String, duration: Double?, mimeType: String, type: SharedMediaType) {
         self.path = path
         self.thumbnail = thumbnail
         self.fileName = fileName
         self.duration = duration
+        self.mimeType = mimeType
         self.type = type
     }
   }

--- a/src/ExpoShareIntentModule.types.ts
+++ b/src/ExpoShareIntentModule.types.ts
@@ -22,8 +22,8 @@ export type ShareIntent = {
 
 export interface ShareIntentFile {
   path: string;
-  type: string;
-  fileName?: string;
+  mimeType: string;
+  fileName: string;
 }
 
 export type IosShareIntent = {
@@ -35,6 +35,8 @@ export type IosShareIntent = {
 export interface IosShareIntentFile {
   path: string;
   type: string;
+  fileName: string;
+  mimeType: string;
 }
 
 export type AndroidShareIntent = {


### PR DESCRIPTION
**Summary**

In order to have the same file description on iOS and Android, we need to get the mimeType from the iOS part.

```js
export interface IosShareIntentFile {
  path: string;
  type: string;
  fileName: string;
  mimeType: string;
}

export interface AndroidShareIntentFile {
  fileName: string;
  filePath: string;
  mimeType: string;
  contentUri: string;
}
```

**Todo**

- [x] Retrieve file mimeType from file extension on iOS
- [x] Harmonize `shareIntent.type` for ios and android
- [x] Update README.md

**Issue**

https://github.com/achorein/expo-share-intent/issues/40
