### PR TITLE
feat: retreive file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ export default const App = () => {
 const { shareIntent } = useShareIntent();
 ```
 
-| attribute            | description                                           | example                                                                                               |
-| -------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `shareIntent.text`   | raw text from text/weburl (ios) and text/\* (android) | "`some text`", "`http://example.com`", "`Hey, Click on my link : http://example.com/nickname`"        |
-| `shareIntent.webUrl` | link extracted from raw text                          | `null`, "`http://example.com`", "`http://example.com/nickname`"                                       |
-| `shareIntent.files`  | image / movies / audio / files with path and type     | `[{ path: "file:///local/path/filename", mimeType: "image/jpeg", fileName: "originalFilename.jpg" }]` |
+| attribute            | description                                                                   | example                                                                                                              |
+| -------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `shareIntent.text`   | raw text from text/weburl (ios) and text/\* (android)                         | "`some text`", "`http://example.com`", "`Hey, Click on my link : http://example.com/nickname`"                       |
+| `shareIntent.webUrl` | link extracted from raw text                                                  | `null`, "`http://example.com`", "`http://example.com/nickname`"                                                      |
+| `shareIntent.files`  | image / movies / audio / files with name, path, mimetype and size (in octets) | `[{ path: "file:///local/path/filename", mimeType: "image/jpeg", fileName: "originalFilename.jpg", size: 2567402 }]` |
 
 #### Customize Content Types in `app.json`
 

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -59,9 +59,11 @@ class ExpoShareIntentModule : Module() {
             val queryResult: Cursor = resolver.query(uri, null, null, null, null)!!
             queryResult.moveToFirst()
             val fileName = queryResult.getString(queryResult.getColumnIndex(OpenableColumns.DISPLAY_NAME))
+            val fileSize = queryResult.getString(queryResult.getColumnIndex(OpenableColumns.SIZE))
             queryResult.close()
             return mapOf(
                     "fileName" to fileName,
+                    "fileSize" to fileSize,
                     "filePath" to instance!!.getAbsolutePath(uri)!!,
                     "mimeType" to resolver.getType(uri)!!,
                     "contentUri" to uri.toString(),

--- a/ios/ExpoShareIntentModule.swift
+++ b/ios/ExpoShareIntentModule.swift
@@ -62,11 +62,11 @@ public class ExpoShareIntentModule: Module {
                         if let path = getAbsolutePath(for: $0.path) {
                             if ($0.type == .video && $0.thumbnail != nil) {
                                 let thumbnail = getAbsolutePath(for: $0.thumbnail!)
-                                return SharedMediaFile.init(path: path, thumbnail: thumbnail, fileName: $0.fileName, duration: $0.duration, mimeType: $0.mimeType, type: $0.type)
+                                return SharedMediaFile.init(path: path, thumbnail: thumbnail, fileName: $0.fileName, fileSize: $0.fileSize, duration: $0.duration, mimeType: $0.mimeType, type: $0.type)
                             } else if ($0.type == .video && $0.thumbnail == nil) {
-                                return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, duration: $0.duration, mimeType: $0.mimeType, type: $0.type)
+                                return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, fileSize: $0.fileSize, duration: $0.duration, mimeType: $0.mimeType, type: $0.type)
                             }
-                            return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, duration: $0.duration, mimeType: $0.mimeType, type: $0.type)
+                            return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, fileSize: $0.fileSize, duration: $0.duration, mimeType: $0.mimeType, type: $0.type)
                         }
                         return nil
                     }
@@ -82,7 +82,7 @@ public class ExpoShareIntentModule: Module {
                     let sharedArray = decode(data: json)
                     let sharedMediaFiles: [SharedMediaFile] = sharedArray.compactMap{
                         if let path = getAbsolutePath(for: $0.path) {
-                            return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, duration: nil, mimeType: $0.mimeType, type: $0.type)
+                            return SharedMediaFile.init(path: path, thumbnail: nil, fileName: $0.fileName, fileSize: $0.fileSize, duration: nil, mimeType: $0.mimeType, type: $0.type)
                         }
                         return nil
                     }
@@ -170,18 +170,20 @@ public class ExpoShareIntentModule: Module {
   class SharedMediaFile: Codable {
     var path: String; // can be image, video or url path
     var thumbnail: String?; // video thumbnail
-    var fileName: String; // video thumbnail
+    var fileName: String; // uuid + extension
+    var fileSize: Int?;
     var duration: Double?; // video duration in milliseconds
     var mimeType: String;
     var type: SharedMediaType;
-
-    init(path: String, thumbnail: String?, fileName: String, duration: Double?, mimeType: String, type: SharedMediaType) {
-        self.path = path
-        self.thumbnail = thumbnail
-        self.fileName = fileName
-        self.duration = duration
-        self.mimeType = mimeType
-        self.type = type
+    
+    init(path: String, thumbnail: String?, fileName: String, fileSize: Int?, duration: Double?, mimeType: String, type: SharedMediaType) {
+      self.path = path
+      self.thumbnail = thumbnail
+      self.fileName = fileName
+      self.fileSize = fileSize
+      self.duration = duration
+      self.mimeType = mimeType
+      self.type = type
     }
   }
 

--- a/src/ExpoShareIntentModule.types.ts
+++ b/src/ExpoShareIntentModule.types.ts
@@ -24,6 +24,7 @@ export interface ShareIntentFile {
   path: string;
   mimeType: string;
   fileName: string;
+  size: number | null;
 }
 
 export type IosShareIntent = {
@@ -37,6 +38,7 @@ export interface IosShareIntentFile {
   type: string;
   fileName: string;
   mimeType: string;
+  fileSize?: number;
 }
 
 export type AndroidShareIntent = {
@@ -49,6 +51,7 @@ export interface AndroidShareIntentFile {
   fileName: string;
   filePath: string;
   mimeType: string;
+  fileSize?: string;
   contentUri: string;
 }
 

--- a/src/useShareIntent.tsx
+++ b/src/useShareIntent.tsx
@@ -73,6 +73,7 @@ const parseShareIntent = (value, options): ShareIntent => {
                 path: f.path || f.contentUri || null,
                 mimeType: f.mimeType || null,
                 fileName: f.fileName || null,
+                size: f.fileSize ? Number(f.fileSize) : null,
               },
             ];
           }, [])


### PR DESCRIPTION
**Summary**

In order to know if we have to resize the given file (media like images), this PR add the shared file size in octets.

```js
export interface ShareIntentFile {
  path: string;
  mimeType: string;
  fileName: string;
  size: number | null;
}
```

**Todo**

- [x] Retrieve fileSize from iOS
- [x] Retrieve fileSize from Android
- [x] Update README.md

**Issue**

https://github.com/achorein/expo-share-intent/issues/34

https://github.com/achorein/expo-share-intent/issues/40
