### PR TITLE
fix: check "eas.build.experimental.ios.appExtensions"  config compati…

### DIFF
--- a/plugin/src/withCompatibilityChecker.ts
+++ b/plugin/src/withCompatibilityChecker.ts
@@ -32,5 +32,15 @@ export const withCompatibilityChecker: ConfigPlugin = (config) => {
     );
   }
 
+  const extraAppExtension =
+    config.extra?.eas?.build?.experimental?.ios?.appExtensions?.filter(
+      (appExtension: any) => appExtension.targetName === "ShareExtension",
+    );
+  if (extraAppExtension && extraAppExtension.length > 1) {
+    throw new Error(
+      `[${packageInfo.name}] Incompatibility found, you have more than one appExtensions for "ShareExtension" (${extraAppExtension.length}). Please remove all "eas.build.experimental.ios.appExtensions" with targetName "ShareExtension" in your app.json! (see https://github.com/achorein/expo-share-intent?tab=readme-ov-file#ios-extension-target)`,
+    );
+  }
+
   return config;
 };


### PR DESCRIPTION
**Summary**

Check the "eas.build.experimental.ios.appExtensions" config compatibilty from `app.json`, avoiding multiple share extension on iOS.

```json
"eas": {
  "build": {
    "experimental": {
      "ios": {
        "appExtensions": [
          {
            "targetName": "ShareExtension",
            "bundleIdentifier": "xxx.xxx.xxx.share-extension",
            "entitlements": {
              "com.apple.security.application-groups": [
                "group.com.robinheidenis.hephaestus"
              ]
            }
          },
          {
            "targetName": "ShareExtension",
            "bundleIdentifier": "xxx.xxx.xxx.share-extension"
          }
        ]
      }
    }
  },
}
```

**Issue**

https://github.com/achorein/expo-share-intent/issues/39
