### PR TITLE
fix: missing scheme on runtime when using expo-updates

### DIFF
--- a/example/basic/App.tsx
+++ b/example/basic/App.tsx
@@ -7,6 +7,7 @@ export default function App() {
     useShareIntent({
       debug: true,
       resetOnBackground: true,
+      scheme: "exposhareintentexample", // needed only when using expo-updates
     });
 
   return (

--- a/example/basic/App.tsx
+++ b/example/basic/App.tsx
@@ -7,7 +7,6 @@ export default function App() {
     useShareIntent({
       debug: true,
       resetOnBackground: true,
-      scheme: "exposhareintentexample", // needed only when using expo-updates
     });
 
   return (

--- a/example/basic/package.json
+++ b/example/basic/package.json
@@ -16,7 +16,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "expo": "~50.0.14",
+    "expo": "~50.0.15",
     "expo-dev-client": "~3.3.11",
     "expo-splash-screen": "~0.26.4",
     "expo-status-bar": "~1.11.1",

--- a/example/basic/yarn.lock
+++ b/example/basic/yarn.lock
@@ -4005,10 +4005,10 @@ expo-modules-autolinking@1.10.3:
     find-up "^5.0.0"
     fs-extra "^9.1.0"
 
-expo-modules-core@1.11.12:
-  version "1.11.12"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.11.12.tgz#d5c7b3ed7ab57d4fb6885a0d8e10287dcf1ffe5f"
-  integrity sha512-/e8g4kis0pFLer7C0PLyx98AfmztIM6gU9jLkYnB1pU9JAfQf904XEi3bmszO7uoteBQwSL6FLp1m3TePKhDaA==
+expo-modules-core@1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.11.13.tgz#a8e63ad844e966dce78dea40b50839af6c3bc518"
+  integrity sha512-2H5qrGUvmLzmJNPDOnovH1Pfk5H/S/V0BifBmOQyDc9aUh9LaDwkqnChZGIXv8ZHDW8JRlUW0QqyWxTggkbw1A==
   dependencies:
     invariant "^2.2.4"
 
@@ -4051,10 +4051,10 @@ expo-updates@~0.24.12:
     fbemitter "^3.0.0"
     resolve-from "^5.0.0"
 
-expo@~50.0.14:
-  version "50.0.14"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-50.0.14.tgz#ddcae86aa0ba8d1be3da9ad1bdda23fa539dc97d"
-  integrity sha512-yLPdxCMVAbmeEIpzzyAuJ79wvr6ToDDtQmuLDMAgWtjqP8x3CGddXxUe07PpKEQgzwJabdHvCLP5Bv94wMFIjQ==
+expo@~50.0.15:
+  version "50.0.15"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-50.0.15.tgz#18c5c3ee0125fd42fe828b6791410eed68f7e74a"
+  integrity sha512-tsyRmMHjA8lPlM7AsqH1smSH8hzmn1+x/vsP+xgbKYJTGtYccdY/wsm6P84VJWeK5peWSVqrWNos+YuPqXKLSQ==
   dependencies:
     "@babel/runtime" "^7.20.0"
     "@expo/cli" "0.17.8"
@@ -4068,7 +4068,7 @@ expo@~50.0.14:
     expo-font "~11.10.3"
     expo-keep-awake "~12.8.2"
     expo-modules-autolinking "1.10.3"
-    expo-modules-core "1.11.12"
+    expo-modules-core "1.11.13"
     fbemitter "^3.0.0"
     whatwg-url-without-unicode "8.0.0-3"
 

--- a/example/expo-router/package.json
+++ b/example/expo-router/package.json
@@ -16,7 +16,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "expo": "~50.0.14",
+    "expo": "~50.0.15",
     "expo-constants": "~15.4.5",
     "expo-linking": "~6.2.2",
     "expo-router": "~3.4.8",

--- a/example/expo-router/yarn.lock
+++ b/example/expo-router/yarn.lock
@@ -4176,10 +4176,10 @@ expo-modules-autolinking@1.10.3:
     find-up "^5.0.0"
     fs-extra "^9.1.0"
 
-expo-modules-core@1.11.12:
-  version "1.11.12"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.11.12.tgz#d5c7b3ed7ab57d4fb6885a0d8e10287dcf1ffe5f"
-  integrity sha512-/e8g4kis0pFLer7C0PLyx98AfmztIM6gU9jLkYnB1pU9JAfQf904XEi3bmszO7uoteBQwSL6FLp1m3TePKhDaA==
+expo-modules-core@1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.11.13.tgz#a8e63ad844e966dce78dea40b50839af6c3bc518"
+  integrity sha512-2H5qrGUvmLzmJNPDOnovH1Pfk5H/S/V0BifBmOQyDc9aUh9LaDwkqnChZGIXv8ZHDW8JRlUW0QqyWxTggkbw1A==
   dependencies:
     invariant "^2.2.4"
 
@@ -4210,10 +4210,10 @@ expo-status-bar@~1.11.1:
   resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.11.1.tgz#a11318741d361048c11db2b16c4364a79a74af30"
   integrity sha512-ddQEtCOgYHTLlFUe/yH67dDBIoct5VIULthyT3LRJbEwdpzAgueKsX2FYK02ldh440V87PWKCamh7R9evk1rrg==
 
-expo@~50.0.14:
-  version "50.0.14"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-50.0.14.tgz#ddcae86aa0ba8d1be3da9ad1bdda23fa539dc97d"
-  integrity sha512-yLPdxCMVAbmeEIpzzyAuJ79wvr6ToDDtQmuLDMAgWtjqP8x3CGddXxUe07PpKEQgzwJabdHvCLP5Bv94wMFIjQ==
+expo@~50.0.15:
+  version "50.0.15"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-50.0.15.tgz#18c5c3ee0125fd42fe828b6791410eed68f7e74a"
+  integrity sha512-tsyRmMHjA8lPlM7AsqH1smSH8hzmn1+x/vsP+xgbKYJTGtYccdY/wsm6P84VJWeK5peWSVqrWNos+YuPqXKLSQ==
   dependencies:
     "@babel/runtime" "^7.20.0"
     "@expo/cli" "0.17.8"
@@ -4227,7 +4227,7 @@ expo@~50.0.14:
     expo-font "~11.10.3"
     expo-keep-awake "~12.8.2"
     expo-modules-autolinking "1.10.3"
-    expo-modules-core "1.11.12"
+    expo-modules-core "1.11.13"
     fbemitter "^3.0.0"
     whatwg-url-without-unicode "8.0.0-3"
 

--- a/example/react-navigation/package.json
+++ b/example/react-navigation/package.json
@@ -19,7 +19,7 @@
     "@react-navigation/native": "^6.1.16",
     "@react-navigation/native-stack": "^6.9.25",
     "@react-navigation/stack": "^6.3.28",
-    "expo": "~50.0.14",
+    "expo": "~50.0.15",
     "expo-splash-screen": "~0.26.4",
     "expo-status-bar": "~1.11.1",
     "patch-package": "^8.0.0",

--- a/example/react-navigation/yarn.lock
+++ b/example/react-navigation/yarn.lock
@@ -4009,10 +4009,10 @@ expo-modules-autolinking@1.10.3:
     find-up "^5.0.0"
     fs-extra "^9.1.0"
 
-expo-modules-core@1.11.12:
-  version "1.11.12"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.11.12.tgz#d5c7b3ed7ab57d4fb6885a0d8e10287dcf1ffe5f"
-  integrity sha512-/e8g4kis0pFLer7C0PLyx98AfmztIM6gU9jLkYnB1pU9JAfQf904XEi3bmszO7uoteBQwSL6FLp1m3TePKhDaA==
+expo-modules-core@1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.11.13.tgz#a8e63ad844e966dce78dea40b50839af6c3bc518"
+  integrity sha512-2H5qrGUvmLzmJNPDOnovH1Pfk5H/S/V0BifBmOQyDc9aUh9LaDwkqnChZGIXv8ZHDW8JRlUW0QqyWxTggkbw1A==
   dependencies:
     invariant "^2.2.4"
 
@@ -4028,10 +4028,10 @@ expo-status-bar@~1.11.1:
   resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.11.1.tgz#a11318741d361048c11db2b16c4364a79a74af30"
   integrity sha512-ddQEtCOgYHTLlFUe/yH67dDBIoct5VIULthyT3LRJbEwdpzAgueKsX2FYK02ldh440V87PWKCamh7R9evk1rrg==
 
-expo@~50.0.14:
-  version "50.0.14"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-50.0.14.tgz#ddcae86aa0ba8d1be3da9ad1bdda23fa539dc97d"
-  integrity sha512-yLPdxCMVAbmeEIpzzyAuJ79wvr6ToDDtQmuLDMAgWtjqP8x3CGddXxUe07PpKEQgzwJabdHvCLP5Bv94wMFIjQ==
+expo@~50.0.15:
+  version "50.0.15"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-50.0.15.tgz#18c5c3ee0125fd42fe828b6791410eed68f7e74a"
+  integrity sha512-tsyRmMHjA8lPlM7AsqH1smSH8hzmn1+x/vsP+xgbKYJTGtYccdY/wsm6P84VJWeK5peWSVqrWNos+YuPqXKLSQ==
   dependencies:
     "@babel/runtime" "^7.20.0"
     "@expo/cli" "0.17.8"
@@ -4045,7 +4045,7 @@ expo@~50.0.14:
     expo-font "~11.10.3"
     expo-keep-awake "~12.8.2"
     expo-modules-autolinking "1.10.3"
-    expo-modules-core "1.11.12"
+    expo-modules-core "1.11.13"
     fbemitter "^3.0.0"
     whatwg-url-without-unicode "8.0.0-3"
 

--- a/src/ExpoShareIntentModule.ts
+++ b/src/ExpoShareIntentModule.ts
@@ -5,11 +5,11 @@ import {
   Subscription,
 } from "expo-modules-core";
 
-import { SHARE_EXTENSION_KEY } from ".";
 import {
   ChangeEventPayload,
   StateEventPayload,
 } from "./ExpoShareIntentModule.types";
+import { getShareExtensionKey } from "./utils";
 
 // Import the native module. it will be resolved on native platforms to ExpoShareIntentModule.ts
 // It loads the native module object from the JSI or falls back to
@@ -22,11 +22,11 @@ export function getShareIntent(url = ""): string {
 }
 
 export function clearShareIntent(key: string) {
-  return ExpoShareIntentModule.clearShareIntent(key ?? SHARE_EXTENSION_KEY);
+  return ExpoShareIntentModule.clearShareIntent(key ?? getShareExtensionKey());
 }
 
 export function hasShareIntent(key: string): boolean {
-  return ExpoShareIntentModule.hasShareIntent(key ?? SHARE_EXTENSION_KEY);
+  return ExpoShareIntentModule.hasShareIntent(key ?? getShareExtensionKey());
 }
 
 const emitter = new EventEmitter(

--- a/src/ExpoShareIntentModule.types.ts
+++ b/src/ExpoShareIntentModule.types.ts
@@ -10,6 +10,7 @@ export type ShareIntentOptions = {
   debug?: boolean;
   resetOnBackground?: boolean;
   disabled?: boolean;
+  scheme?: string;
   onResetShareIntent?: () => void;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import Constants from "expo-constants";
 
 export { ShareIntent } from "./ExpoShareIntentModule.types";
 
-export const SHARE_EXTENSION_KEY = `${Constants.expoConfig?.scheme}ShareKey`;
 export {
   hasShareIntent,
   getShareIntent,
@@ -13,6 +12,9 @@ export {
 } from "./ExpoShareIntentModule";
 
 export { default as useShareIntent } from "./useShareIntent";
+
+export { getScheme, getShareExtensionKey } from "./utils";
+
 export {
   ShareIntentProvider,
   useShareIntentContext,

--- a/src/useShareIntent.tsx
+++ b/src/useShareIntent.tsx
@@ -104,7 +104,9 @@ export default function useShareIntent(
     if (options.disabled) return;
     setError(null);
     clearNativeModule &&
-      clearShareIntent(`${Constants.expoConfig?.scheme}ShareKey`);
+      clearShareIntent(
+        `${Constants.expoConfig?.scheme || options.scheme}ShareKey`,
+      );
     if (shareIntent?.text || shareIntent?.files) {
       setSharedIntent(SHAREINTENT_DEFAULTVALUE);
       options.onResetShareIntent?.();
@@ -116,7 +118,16 @@ export default function useShareIntent(
    */
   const refreshShareIntent = () => {
     options.debug && console.debug("useShareIntent[refresh]", url);
-    if (url?.startsWith(`${Constants.expoConfig?.scheme}://dataUrl`)) {
+    if (Platform.OS === "ios" && !Constants.expoConfig?.scheme) {
+      console.warn(
+        `Constants.expoConfig.scheme is empty! Falling back to options.scheme "${options.scheme}"`,
+      );
+    }
+    if (
+      url?.startsWith(
+        `${Constants.expoConfig?.scheme || options.scheme}://dataUrl`,
+      )
+    ) {
       // iOS only
       getShareIntent(url);
     } else if (Platform.OS === "android") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,34 @@
+import Constants from "expo-constants";
+import { createURL } from "expo-linking";
+
+import { ShareIntentOptions } from "./ExpoShareIntentModule.types";
+
+export const getScheme = (options?: ShareIntentOptions) => {
+  if (options?.scheme !== undefined) {
+    options?.debug &&
+      console.debug("expoShareIntent[scheme] from option:", options.scheme);
+    return options.scheme;
+  }
+  if (Constants.expoConfig?.scheme) {
+    options?.debug &&
+      console.debug(
+        "expoShareIntent[scheme] from expoConfig:",
+        Constants.expoConfig?.scheme,
+      );
+    return Constants.expoConfig?.scheme;
+  }
+  const deepLinkUrl = createURL("dataUrl=");
+  const extracted = deepLinkUrl.match(/^([^:]+)/gi)?.[0] || null;
+  options?.debug &&
+    console.debug(
+      "expoShareIntent[scheme] from linking url:",
+      deepLinkUrl,
+      extracted,
+    );
+  return extracted;
+};
+
+export const getShareExtensionKey = (options?: ShareIntentOptions) => {
+  const scheme = getScheme(options);
+  return `${scheme}ShareKey`;
+};


### PR DESCRIPTION
**Summary**

When using `expo-updates` in a release build, sometimes the scheme is no availaible in the runtime (`Constants.expoConfig?.scheme`)

similar issue : `https://github.com/expo/custom-expo-updates-server/issues/12`

**Todo**

- [x] fallback to `Linking.createUrl` if missing
- [x] Provide a option to force scheme value
```js
    useShareIntent({
      scheme: "exposhareintentexample",
    });
```
```jsx
    <ShareIntentProvider
      options={{
          scheme: "exposhareintentexample",
      }}
    >
```
- [x] Update react-navigation demo to replace `Constants.expoConfig?.scheme` in custom linking configuration
- [ ] Update README.md

**Issue**

https://github.com/achorein/expo-share-intent/issues/46

**Testing**

https://docs.expo.dev/eas-update/debug-advanced/#ios-local-builds

```
yarn ios ---configuration Release
```
