### PR TITLE
fix: handle ios privacy manifest

### DIFF
--- a/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
+++ b/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
@@ -28,14 +28,19 @@ export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (
     const currentProjectVersion = config.ios!.buildNumber || "1";
     const marketingVersion = config.version!;
 
+    // ShareExtension-Info.plist
     const infoPlistFilePath =
       getShareExtensionInfoFilePath(platformProjectRoot);
+    // ShareExtension.entitlements
     const entitlementsFilePath =
       getShareExtensionEntitlementsFilePath(platformProjectRoot);
+    // ShareViewController.swift
     const viewControllerFilePath =
       getShareExtensionViewControllerPath(platformProjectRoot);
+    // MainInterface.storyboard
     const storyboardFilePath =
       getShareExtensionStoryboardFilePath(platformProjectRoot);
+    // PrivacyInfo.xcprivacy
     const privacyFilePath = getPrivacyInfoFilePath(platformProjectRoot);
 
     await writeShareExtensionFiles(
@@ -63,7 +68,6 @@ export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (
     );
 
     // Add a new PBXResourcesBuildPhase for the Resources used by the Share Extension
-    // (MainInterface.storyboard)
     pbxProject.addBuildPhase(
       [],
       "PBXResourcesBuildPhase",
@@ -74,17 +78,18 @@ export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (
     // Create a separate PBXGroup for the shareExtension's files
     const pbxGroupKey = pbxProject.pbxCreateGroup(extensionName, extensionName);
 
-    // Add files which are not part of any build phase (plist)
+    // Add files which are not part of any build phase (ShareExtension-Info.plist)
     pbxProject.addFile(infoPlistFilePath, pbxGroupKey);
 
-    // Add source files to our PbxGroup and our newly created PBXSourcesBuildPhase
+    // Add source files to our PbxGroup and our newly created PBXSourcesBuildPhase (ShareViewController.swift)
     pbxProject.addSourceFile(
       viewControllerFilePath,
       { target: target.uuid },
       pbxGroupKey,
     );
 
-    //  Add the resource file and include it into the target PbxResourcesBuildPhase and PbxGroup
+    // Add the resource file and include it into the target PbxResourcesBuildPhase and PbxGroup
+    // (MainInterface.storyboard / PrivacyInfo.xcprivacy)
     pbxProject.addResourceFile(
       storyboardFilePath,
       { target: target.uuid },

--- a/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
+++ b/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
@@ -5,6 +5,7 @@ import {
   shareExtensionName,
 } from "./constants";
 import {
+  getPrivacyInfoFilePath,
   getShareExtensionEntitlementsFilePath,
   getShareExtensionInfoFilePath,
   getShareExtensionStoryboardFilePath,
@@ -35,6 +36,7 @@ export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (
       getShareExtensionViewControllerPath(platformProjectRoot);
     const storyboardFilePath =
       getShareExtensionStoryboardFilePath(platformProjectRoot);
+    const privacyFilePath = getPrivacyInfoFilePath(platformProjectRoot);
 
     await writeShareExtensionFiles(
       platformProjectRoot,
@@ -85,6 +87,11 @@ export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (
     //  Add the resource file and include it into the target PbxResourcesBuildPhase and PbxGroup
     pbxProject.addResourceFile(
       storyboardFilePath,
+      { target: target.uuid },
+      pbxGroupKey,
+    );
+    pbxProject.addResourceFile(
+      privacyFilePath,
       { target: target.uuid },
       pbxGroupKey,
     );

--- a/plugin/src/ios/writeIosShareExtensionFiles.ts
+++ b/plugin/src/ios/writeIosShareExtensionFiles.ts
@@ -18,6 +18,7 @@ export async function writeShareExtensionFiles(
   appIdentifier: string,
   parameters: Parameters,
 ) {
+  // ShareExtension-Info.plist
   const infoPlistFilePath = getShareExtensionInfoFilePath(platformProjectRoot);
   const infoPlistContent = getShareExtensionInfoContent(
     parameters.iosActivationRules,
@@ -25,21 +26,25 @@ export async function writeShareExtensionFiles(
   await fs.promises.mkdir(path.dirname(infoPlistFilePath), { recursive: true });
   await fs.promises.writeFile(infoPlistFilePath, infoPlistContent);
 
+  // ShareExtension.entitlements
   const entitlementsFilePath =
     getShareExtensionEntitlementsFilePath(platformProjectRoot);
   const entitlementsContent =
     getShareExtensionEntitlementsContent(appIdentifier);
   await fs.promises.writeFile(entitlementsFilePath, entitlementsContent);
 
+  // PrivacyInfo.xcprivacy
   const pricayFilePath = getPrivacyInfoFilePath(platformProjectRoot);
   const pricayContent = getPrivacyInfoContent();
   await fs.promises.writeFile(pricayFilePath, pricayContent);
 
+  // MainInterface.storyboard
   const storyboardFilePath =
     getShareExtensionStoryboardFilePath(platformProjectRoot);
   const storyboardContent = getShareExtensionStoryBoardContent();
   await fs.promises.writeFile(storyboardFilePath, storyboardContent);
 
+  // ShareViewController.swift
   const viewControllerFilePath =
     getShareExtensionViewControllerPath(platformProjectRoot);
   const viewControllerContent = getShareExtensionViewControllerContent(
@@ -49,7 +54,7 @@ export async function writeShareExtensionFiles(
   await fs.promises.writeFile(viewControllerFilePath, viewControllerContent);
 }
 
-//: [root]/ios/ShareExtension/ShareExtension-Entitlements.plist
+//: [root]/ios/ShareExtension/ShareExtension.entitlements
 export function getShareExtensionEntitlementsFilePath(
   platformProjectRoot: string,
 ) {
@@ -103,6 +108,7 @@ export function getShareExtensionInfoContent(
   });
 }
 
+//: [root]/ios/ShareExtension/PrivacyInfo.xcprivacy
 export function getPrivacyInfoFilePath(platformProjectRoot: string) {
   return path.join(
     platformProjectRoot,
@@ -124,7 +130,7 @@ export function getPrivacyInfoContent() {
   });
 }
 
-//: [root]/ios/ShareExtension/ShareExtension-Info.plist
+//: [root]/ios/ShareExtension/MainInterface.storyboard
 export function getShareExtensionStoryboardFilePath(
   platformProjectRoot: string,
 ) {

--- a/plugin/src/ios/writeIosShareExtensionFiles.ts
+++ b/plugin/src/ios/writeIosShareExtensionFiles.ts
@@ -31,6 +31,10 @@ export async function writeShareExtensionFiles(
     getShareExtensionEntitlementsContent(appIdentifier);
   await fs.promises.writeFile(entitlementsFilePath, entitlementsContent);
 
+  const pricayFilePath = getPrivacyInfoFilePath(platformProjectRoot);
+  const pricayContent = getPrivacyInfoContent();
+  await fs.promises.writeFile(pricayFilePath, pricayContent);
+
   const storyboardFilePath =
     getShareExtensionStoryboardFilePath(platformProjectRoot);
   const storyboardContent = getShareExtensionStoryBoardContent();
@@ -99,6 +103,27 @@ export function getShareExtensionInfoContent(
   });
 }
 
+export function getPrivacyInfoFilePath(platformProjectRoot: string) {
+  return path.join(
+    platformProjectRoot,
+    shareExtensionName,
+    "PrivacyInfo.xcprivacy",
+  );
+}
+
+export function getPrivacyInfoContent() {
+  return plist.build({
+    NSPrivacyAccessedAPITypes: [
+      {
+        NSPrivacyAccessedAPIType: "NSPrivacyAccessedAPICategoryUserDefaults",
+        NSPrivacyAccessedAPITypeReasons: ["CA92.1"],
+      },
+    ],
+    NSPrivacyCollectedDataTypes: [],
+    NSPrivacyTracking: false,
+  });
+}
+
 //: [root]/ios/ShareExtension/ShareExtension-Info.plist
 export function getShareExtensionStoryboardFilePath(
   platformProjectRoot: string,
@@ -158,7 +183,7 @@ export function getShareExtensionViewControllerContent(
   );
   if (!scheme) {
     throw new Error(
-      "[expo-share-intent] missing custom URL scheme 'expo.scheme' in app.json ! (see https://docs.expo.dev/guides/linking/#linking-to-your-app)"
+      "[expo-share-intent] missing custom URL scheme 'expo.scheme' in app.json ! (see https://docs.expo.dev/guides/linking/#linking-to-your-app)",
     );
   }
 


### PR DESCRIPTION
**Summary**

>ITMS-91053: Missing API declaration - Your app’s code in the “PlugIns/ShareExtension.appex/ShareExtension” file references one or more APIs that require reasons, including the following API categories: NSPrivacyAccessedAPICategoryUserDefaults. While no action is required at this time, starting May 1, 2024, when you upload a new app or app update, you must include a NSPrivacyAccessedAPITypes array in your app’s privacy manifest to provide approved reasons for these APIs used by your app’s code. For more details about this policy, including a list of required reason APIs and approved reasons for usage, visit: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api.

Related to `https://github.com/expo/expo/pull/28005` and `https://github.com/expo/expo/pull/28082`

**Todo**

- [x] Generate `ios/ShareExtension/PrivacyInfo.xcprivacy`
- [x] Add reference to `PrivacyInfo.xcprivacy` in `project.pbxproj`

**Issue**

Fixes https://github.com/achorein/expo-share-intent/issues/49
