### PR TITLE
fix: android exception on multiple files sharing

### DIFF
--- a/example/basic/App.tsx
+++ b/example/basic/App.tsx
@@ -59,5 +59,6 @@ const styles = StyleSheet.create({
   },
   error: {
     color: "red",
+    marginTop: 20,
   },
 });


### PR DESCRIPTION
**Summary**

**Todo**

- [x] Handle exception on `getAbsolutePath` (using contentUri instead)
- [x] Fix `getParcelableArrayListExtra` extension

**Issue**

Fixes https://github.com/achorein/expo-share-intent/issues/33
