### PR TITLE
fix: correct config index

### DIFF
--- a/plugin/src/ios/withIosShareExtensionConfig.ts
+++ b/plugin/src/ios/withIosShareExtensionConfig.ts
@@ -50,7 +50,8 @@ export const withShareExtensionConfig: ConfigPlugin<Parameters> = (
         targetName: extName,
         bundleIdentifier: shareExtensionIdentifier,
       });
-      extConfigIndex = 0;
+      extConfigIndex =
+        config.extra.eas.build.experimental.ios.appExtensions.length - 1;
     }
 
     const extConfig =


### PR DESCRIPTION
**Summary**
This fixes building issue when `appExtensions` is non-empty. `extConfigIndex` must be set to the last index after appending new entitlement

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Issue** https://github.com/achorein/expo-share-intent/issues/32
<!-- If you have a GitHub Issue -->
