### PR TITLE
fix: ios - ensure the target is not added to main project multiple times (during prebuild)

### DIFF
--- a/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
+++ b/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
@@ -53,6 +53,11 @@ export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (
 
     const pbxProject = config.modResults;
 
+    // Check if the extension target already exists. If so, abort the process since the steps below are already done.
+    if (!!pbxProject.pbxTargetByName(extensionName)) {
+      return config;
+    }
+
     const target = pbxProject.addTarget(
       extensionName,
       "app_extension",


### PR DESCRIPTION
**Summary**

Every time I run `npx expo prebuild`, a duplicate target is added on the xcode main project. This is wrong and causes build failures.

This PR adds checks to skip the process if the target was previously added to the main project.
