### PR TITLE
fix: add explicit error message for patch-package requirement

### DIFF
--- a/plugin/src/ios/constants.ts
+++ b/plugin/src/ios/constants.ts
@@ -1,6 +1,6 @@
 import { Parameters } from "../types";
 
-export const shareExtensionName = "ShareExtension";
+const shareExtensionName = "ShareExtension";
 
 export const shareExtensionInfoFileName = `${shareExtensionName}-Info.plist`;
 export const shareExtensionEntitlementsFileName = `${shareExtensionName}.entitlements`;
@@ -8,7 +8,7 @@ export const shareExtensionStoryBoardFileName = "MainInterface.storyboard";
 export const shareExtensionViewControllerFileName = "ShareViewController.swift";
 
 export const getShareExtensionName = (parameters?: Parameters) => {
-  if (!parameters?.iosShareExtensionName) return "ShareExtension";
+  if (!parameters?.iosShareExtensionName) return shareExtensionName;
   return parameters.iosShareExtensionName.replace(/[^a-zA-Z0-9]/g, "");
 };
 

--- a/plugin/src/ios/withIosShareExtensionConfig.ts
+++ b/plugin/src/ios/withIosShareExtensionConfig.ts
@@ -2,7 +2,7 @@ import { ConfigPlugin } from "@expo/config-plugins";
 
 import {
   getShareExtensionBundledIdentifier,
-  shareExtensionName,
+  getShareExtensionName,
 } from "./constants";
 import { getShareExtensionEntitlements } from "./writeIosShareExtensionFiles";
 import { Parameters } from "../types";
@@ -11,7 +11,7 @@ export const withShareExtensionConfig: ConfigPlugin<Parameters> = (
   config,
   parameters,
 ) => {
-  const extName = shareExtensionName;
+  const extName = getShareExtensionName(parameters);
   const appIdentifier = config.ios!.bundleIdentifier!;
   const shareExtensionIdentifier = getShareExtensionBundledIdentifier(
     appIdentifier,

--- a/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
+++ b/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
@@ -109,16 +109,26 @@ export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (
 
     // Add the resource file and include it into the target PbxResourcesBuildPhase and PbxGroup
     // (MainInterface.storyboard / PrivacyInfo.xcprivacy)
-    pbxProject.addResourceFile(
-      storyboardFilePath,
-      { target: target.uuid },
-      pbxGroupKey,
-    );
-    pbxProject.addResourceFile(
-      privacyFilePath,
-      { target: target.uuid },
-      pbxGroupKey,
-    );
+    try {
+      pbxProject.addResourceFile(
+        storyboardFilePath,
+        { target: target.uuid },
+        pbxGroupKey,
+      );
+      pbxProject.addResourceFile(
+        privacyFilePath,
+        { target: target.uuid },
+        pbxGroupKey,
+      );
+    } catch (e: any) {
+      if (e.message.includes("reading 'path'")) {
+        console.error(e);
+        throw new Error(
+          `[expo-share-intent] Could not add resource files to the Share Extension, please check your "patch-package" installation for xcode (see: https://github.com/achorein/expo-share-intent?tab=readme-ov-file#installation)`,
+        );
+      }
+      throw e;
+    }
 
     const configurations = pbxProject.pbxXCBuildConfigurationSection();
     for (const key in configurations) {


### PR DESCRIPTION
**Summary**

```sh
✖ Prebuild failed
Error: [ios.xcodeproj]: withIosXcodeprojBaseMod: [expo-share-intent] Could not add resource files to the Share Extension, please check your "patch-package" installation for xcode (see: https://github.com/achorein/expo-share-intent?tab=readme-ov-file#installation)
```

**Todo**

- [x] Change error message on expo prebuild command for ios when xcode path it's not applied

**Issue**

<!-- If you have a GitHub Issue -->
