### PR TITLE
feat: iOS context menu

### DIFF
--- a/plugin/src/ios/contextmenu/AppDelegate.swift
+++ b/plugin/src/ios/contextmenu/AppDelegate.swift
@@ -1,0 +1,37 @@
+//
+//  AppDelegate.swift
+//  ContextMenu
+//
+//  Created by Karthikeyan T on 15/03/2020.
+//  Copyright © 2020 Karthikeyan T. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/plugin/src/ios/contextmenu/Base.lproj/LaunchScreen.storyboard
+++ b/plugin/src/ios/contextmenu/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/plugin/src/ios/contextmenu/Base.lproj/Main.storyboard
+++ b/plugin/src/ios/contextmenu/Base.lproj/Main.storyboard
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ContextMenu" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XA2-MC-kUO">
+                                <rect key="frame" x="20" y="54" width="200" height="150"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="150" id="MLR-iH-Ksr"/>
+                                    <constraint firstAttribute="width" constant="200" id="xEO-Cw-9Uo"/>
+                                </constraints>
+                                <state key="normal" image="carImage.JPG"/>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="XA2-MC-kUO" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="ISx-No-NYH"/>
+                            <constraint firstItem="XA2-MC-kUO" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="uyp-q2-Bko"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                    <connections>
+                        <outlet property="someImageButton" destination="XA2-MC-kUO" id="Ff2-f3-Pod"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="137.68115942028987" y="112.5"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="carImage.JPG" width="1024" height="768"/>
+    </resources>
+</document>

--- a/plugin/src/ios/contextmenu/Info.plist
+++ b/plugin/src/ios/contextmenu/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/plugin/src/ios/contextmenu/SceneDelegate.swift
+++ b/plugin/src/ios/contextmenu/SceneDelegate.swift
@@ -1,0 +1,53 @@
+//
+//  SceneDelegate.swift
+//  ContextMenu
+//
+//  Created by Karthikeyan T on 15/03/2020.
+//  Copyright © 2020 Karthikeyan T. All rights reserved.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/plugin/src/ios/contextmenu/ViewController.swift
+++ b/plugin/src/ios/contextmenu/ViewController.swift
@@ -1,0 +1,116 @@
+//
+//  ViewController.swift
+//  ContextMenu
+//
+//  Created by Karthikeyan T on 15/03/2020.
+//  Copyright © 2020 Karthikeyan T. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+    
+    let carImage    = UIImage(named: "carImage.JPG")
+    let copyIcon    = UIImage(named: "copyIcon.png")
+    let shareIcon   = UIImage(named: "shareIcon.png")
+    let removeIcon  = UIImage(named: "binIcon.png")
+    let editIcon    = UIImage(named: "editIcon.png")
+    
+    @IBOutlet weak var someImageButton : UIButton! {
+        didSet {
+            someImageButton.setImage(carImage, for: .normal)
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+        
+        // Create a UIContextMenuInteraction with UIContextMenuInteractionDelegate
+        let interaction = UIContextMenuInteraction(delegate: self)
+        
+        // Attach It to Our View
+        someImageButton.addInteraction(interaction)
+    }
+}
+
+
+extension ViewController : UIContextMenuInteractionDelegate {
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
+        
+        return UIContextMenuConfiguration(identifier: "CarImage" as NSCopying,
+                                          previewProvider: makeImagePreview, //pass nil, if custom preview not needed
+                                          actionProvider: { _ in
+                                            
+                                            let hideImageAction = UIAction(title: "Hide the Image",
+                                                                           identifier: nil,
+                                                                           discoverabilityTitle: nil,
+                                                                           handler: { _ in
+                                                                            print("Hide Image Action")
+                                            })
+                                            
+                                            let editMenu = self.makeEditMenu()
+                                            return UIMenu(title: "Menu",
+                                                          children: [editMenu, hideImageAction])
+        })
+    }
+    
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
+                                willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration,
+                                animator: UIContextMenuInteractionCommitAnimating) {
+        print("(configuration.identifier = \(configuration.identifier)")
+    }
+    
+    func makeEditMenu() -> UIMenu {
+        let editImageAction = UIAction(title: "Edit Image",
+                                       image: editIcon,
+                                       identifier: nil,
+                                       attributes: .disabled) { _ in //.hidden - to hide the action
+                                        print("Edit Image Action")
+        }
+        
+        let copyAction = UIAction(title: "Copy",
+                                  image: copyIcon,
+                                  identifier: nil,
+                                  state: .on) { _ in
+                                    print("Copy Action")
+        }
+                
+        let shareAction = UIAction(title: "Share",
+                                   image: shareIcon,
+                                   identifier: nil,
+                                   discoverabilityTitle:"To share the iamge to any social media") { _ in
+            print("Share Action")
+        }
+        
+        let removeAction = UIAction(title: "Remove",
+                                    image: self.removeIcon,
+                                    identifier: nil,
+                                    discoverabilityTitle: nil,
+                                    attributes: .destructive, //disabled, destructive, hidden
+                                    handler: { _ in
+            print("Remove Action")
+        })
+        
+        return UIMenu(title: "Edit",
+                      image: editIcon,
+                      options: [.displayInline], // [], .displayInline, .destructive
+            children: [editImageAction, copyAction, shareAction, removeAction])
+    }
+    
+    func makeImagePreview() -> UIViewController {
+        let viewController = UIViewController()
+        
+        let imageView = UIImageView(image:carImage)
+        imageView.contentMode = .scaleAspectFit
+        viewController.view = imageView
+        
+        imageView.frame = CGRect(x: 0, y: 0, width: someImageButton.frame.size.width * 1.75, height: someImageButton.frame.size.height * 1.75)
+        
+        viewController.preferredContentSize = imageView.frame.size
+        viewController.view.backgroundColor = .clear
+        
+        return viewController
+    }
+}
+


### PR DESCRIPTION
**Summary**

Add a context menu to provides access Share Intent that’s directly related to an item, without cluttering the interface.
![image](https://github.com/user-attachments/assets/69e233e6-a4ae-4610-8b80-3b8073cfdf41)

Documentation
https://developer.apple.com/design/human-interface-guidelines/context-menus
https://github.com/Karthikeyan-Thiru/ContextMenu_part-1/

**Todo**

- [ ] Add new iOS target (plugin)
- [ ] Configure access to related item
- [ ] Add app.json specific configuration
- [ ] Update README.md

**Issue**

Fixes https://github.com/achorein/expo-share-intent/issues/47