### PR TITLE
fix: replaced console.debug with console.warn to avoid printing to stdout

### DIFF
--- a/plugin/src/android/withAndroidIntentFilters.ts
+++ b/plugin/src/android/withAndroidIntentFilters.ts
@@ -76,7 +76,7 @@ function addIntentFilters(
   // DEFAULT VALUE (text and url)
   const newFilters: Parameters["androidIntentFilters"] = filters || ["text/*"];
 
-  console.debug(
+  console.warn(
     `[expo-share-intent] add android filters (${newFilters.join(" ")}) and multi-filters (${multiFilters ? multiFilters.join(" ") : ""})`,
   );
   const newIntentFilters = [

--- a/plugin/src/ios/withIosShareExtensionConfig.ts
+++ b/plugin/src/ios/withIosShareExtensionConfig.ts
@@ -63,7 +63,7 @@ export const withShareExtensionConfig: ConfigPlugin<Parameters> = (
       ...getShareExtensionEntitlements(appIdentifier, parameters),
     };
   } else {
-    console.debug(`[expo-share-intent] experimental config disabled`);
+    console.warn(`[expo-share-intent] experimental config disabled`);
   }
 
   return config;

--- a/plugin/src/ios/writeIosShareExtensionFiles.ts
+++ b/plugin/src/ios/writeIosShareExtensionFiles.ts
@@ -280,12 +280,12 @@ export function getShareExtensionViewControllerContent(
 ) {
   let updatedScheme = scheme;
   if (Array.isArray(scheme)) {
-    console.debug(
+    console.warn(
       `[expo-share-intent] multiple scheme detected (${scheme.join(",")}), using:${updatedScheme}`,
     );
     updatedScheme = scheme[0];
   }
-  console.debug(
+  console.warn(
     `[expo-share-intent] add ios share extension (scheme:${updatedScheme} groupIdentifier:${groupIdentifier})`,
   );
   if (!updatedScheme) {


### PR DESCRIPTION
When Expo creates the config JSON dynamically, it seems that stdout outputs are taken into account. To avoid messing up the JSON, all debug prints should go to stderr. This PR does so by replacing `console.debug` with `console.warn`, fixing #157. Unfortunately, it does not fix #159.
