### PR TITLE
fix: google files app open new instance within files app

### DIFF
--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -112,6 +112,15 @@ class ExpoShareIntentModule : Module() {
         }
 
         fun handleShareIntent(intent: Intent) {
+            val activity = instance?.currentActivity
+            if (activity != null && !activity.isTaskRoot) {
+                val newIntent = Intent(intent).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                activity.startActivity(newIntent)
+                activity.finish()
+                return
+            }
             if (intent.type == null) return
             if (intent.type!!.startsWith("text/plain")) {
                 // text / urls


### PR DESCRIPTION
**Summary**

When sharing something from `Google Files` app, this open actually open a new instance of the app into `Google Files` app even if one is already running in background.
I've taken a look into `AndroidManifest.xml` and `android:launchMode="singleTask"` is properly set.
I've also tried to add `android:taskAffinity=""` or `android:documentLaunchMode="none"` and it doesn't fix the issue.
After lot of research I've found this thread with this particular comment https://github.com/facebook/react-native/issues/39553#issuecomment-1805467534 and I've adapted the code to this library.




