### PR TITLE
feat: add support for pkpass MIME type (iOS)

### DIFF
--- a/plugin/src/ios/ShareExtensionViewController.swift
+++ b/plugin/src/ios/ShareExtensionViewController.swift
@@ -590,6 +590,7 @@ internal let mimeTypes = [
   "cco": "application/x-cocoa",
   "jardiff": "application/x-java-archive-diff",
   "jnlp": "application/x-java-jnlp-file",
+  "pkpass": "application/vnd.apple.pkpass",
   "run": "application/x-makeself",
   "pl": "application/x-perl",
   "pm": "application/x-perl",


### PR DESCRIPTION
**Summary**

These changes allow the Share Extension to reliably detect, handle, and process .pkpass files shared to the app—such as boarding passes, event tickets, or coupons from Apple Wallet. It enhances the module's flexibility and aligns with modern iOS capabilities.

Add pkpass UTI Constant
Extend File Handling Logic
Handle pkpass method
Update Extension Logic to Recognize .pkpass Files by Name

**Todo**

<!--
- [ ] ${{ Todo item }}
- [ ] Update README.md
-->

**Issue**

Fixes https://github.com/achorein/expo-share-intent/issues/169