### PR TITLE
Fix/screenshot share crashing on latest Xcode (26) / react-native (0.81) / expo version (54)

### DIFF
--- a/plugin/src/ios/ShareExtensionViewController.swift
+++ b/plugin/src/ios/ShareExtensionViewController.swift
@@ -180,7 +180,7 @@ class ShareViewController: UIViewController {
                   NSLog("[ERROR] Cannot load pkpass content: Item was neither URL nor Data for type \(self.pkpassContentType). Attachment: \(attachment)")
                   // Ensure dismissWithError runs on the main thread if it interacts with UI
                   Task { @MainActor in
-                      await self.dismissWithError(message: "Cannot load pkpass content (unexpected data type).")
+                      self.dismissWithError(message: "Cannot load pkpass content (unexpected data type).")
                   }
               }
           } catch {
@@ -188,7 +188,7 @@ class ShareViewController: UIViewController {
               NSLog("[ERROR] Exception when handling pkpass: \(error.localizedDescription)")
               // Ensure dismissWithError runs on the main thread if it interacts with UI
               Task { @MainActor in
-                  await self.dismissWithError(message: "Error processing pkpass: \(error.localizedDescription)")
+                  self.dismissWithError(message: "Error processing pkpass: \(error.localizedDescription)")
               }
           }
       }


### PR DESCRIPTION
**Summary**

Good morning @achorein,

Somehow after upgrading the system image on my phone to Xcode 26 & going to the latest react-native / expo version, screenshot sharing began crashing the share extension in my production app. I'm really not sure where / what exactly changed with all these version bumps, but I would assume it was Xcode / iOS code changes related. This PR addresses the crash and fixes the screenshot sharing, as well as adds a little debug logging if things go south. 

Also unrelated but Xcode was suggesting that a couple of the `await` expressions were unnecessary so I removed them. Unrelated but did silence some build warnings.

Before PR:

https://github.com/user-attachments/assets/f0be70a0-8230-4b1b-abad-9c3ccf1827ce

After PR:


https://github.com/user-attachments/assets/3e768db1-0809-482b-af36-493117aee496



**Issue**

Never created one, just addressed it via PR.
