### PR TITLE
feat: add vCard file sharing support in iOS share extension

### DIFF
--- a/plugin/src/ios/ShareExtensionViewController.swift
+++ b/plugin/src/ios/ShareExtensionViewController.swift
@@ -24,6 +24,7 @@ class ShareViewController: UIViewController {
   let fileURLType: String = UTType.fileURL.identifier
   let pkpassContentType: String = "com.apple.pkpass"
   let pdfContentType: String = UTType.pdf.identifier
+  let vcardContentType: String = "public.vcard"
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -44,6 +45,8 @@ class ShareViewController: UIViewController {
           await handleImages(content: content, attachment: attachment, index: index)
         } else if attachment.hasItemConformingToTypeIdentifier(videoContentType) {
           await handleVideos(content: content, attachment: attachment, index: index)
+        } else if attachment.hasItemConformingToTypeIdentifier(vcardContentType) {
+          await handleVCard(content: content, attachment: attachment, index: index) 
         } else if attachment.hasItemConformingToTypeIdentifier(fileURLType) {
           await handleFiles(content: content, attachment: attachment, index: index)
         } else if attachment.hasItemConformingToTypeIdentifier(pkpassContentType) {
@@ -60,6 +63,33 @@ class ShareViewController: UIViewController {
           NSLog("[ERROR] content type not handle !\(String(describing: content))")
           dismissWithError(message: "content type not handle \(String(describing: content)))")
         }
+      }
+    }
+  }
+
+  private func handleVCard(content: NSExtensionItem, attachment: NSItemProvider, index: Int) async {
+    Task.detached {
+      do {
+        if let url = try? await attachment.loadItem(forTypeIdentifier: self.vcardContentType) as? URL {
+          // ensure a .vcf file extension so mime resolves properly
+          let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".vcf")
+          _ = self.copyFile(at: url, to: tmp)
+          Task { @MainActor in
+            await self.handleFileURL(content: content, url: tmp, index: index)
+          }
+        } else if let data = try? await attachment.loadItem(forTypeIdentifier: self.vcardContentType) as? Data {
+          let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".vcf")
+          try data.write(to: tmp)
+          Task { @MainActor in
+            await self.handleFileURL(content: content, url: tmp, index: index)
+          }
+        } else {
+          NSLog("[ERROR] Cannot load vcard content !\(String(describing: content))")
+          await self.dismissWithError(message: "Cannot load vCard content \(String(describing: content))")
+        }
+      } catch {
+        NSLog("[ERROR] handleVCard exception: \(error.localizedDescription)")
+        await self.dismissWithError(message: "vCard error: \(error.localizedDescription)")
       }
     }
   }
@@ -727,6 +757,7 @@ internal let mimeTypes = [
   "asf": "video/x-ms-asf",
   "wmv": "video/x-ms-wmv",
   "avi": "video/x-msvideo",
+  "vcf": "text/vcard",
 ]
 
 extension URL {


### PR DESCRIPTION
# feat: add vCard file sharing support in iOS share extension

## Description

Adds native vCard (contact) file sharing support to the iOS share extension, allowing users to share contact files (.vcf) from other apps directly into Expo apps.

## Changes

- Added `vcardContentType` constant for "public.vcard" MIME type
- Implemented `handleVCard` function with comprehensive error handling
- Added vCard detection logic in the main content processing flow
- Support for both URL and Data attachment types
- Automatic .vcf file extension assignment for proper MIME type resolution
- Enhanced logging for debugging vCard processing

## Technical Details

The implementation handles vCard data as both URL references and raw Data objects. When processing Data objects, it creates temporary .vcf files to ensure proper MIME type resolution. Uses `Task.detached` for async file operations off the main thread.

## Testing

To test vCard sharing functionality, set your `iosActivationRules` to the following :

```javascript
`SUBQUERY(
    extensionItems,
    $item,
    SUBQUERY(
	    $item.attachments,
	    $attachment,
	    (
	    ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url" ||
	    ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image" ||
	    ANY $attachment.registeredTypeIdentifiers == "public.vcard" ||
	    ANY $attachment.registeredTypeIdentifiers == "public.text" ||
	    ANY $attachment.registeredTypeIdentifiers == "public.data" ||
	    ANY $attachment.registeredTypeIdentifiers == "com.adobe.pdf"
	    )
    ).@count == 1
  ).@count == 1`
```
