### PR TITLE
fix(android): copy file to cache before querying + handle text/plain files

### DIFF
--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -173,9 +173,14 @@ class ExpoShareIntentModule : Module() {
                 return
             }
             if (intent.type == null) return
-            if (intent.type!!.startsWith("text/plain")) {
-                // text / urls
-                if (intent.action == Intent.ACTION_SEND) {
+
+            if (intent.action == Intent.ACTION_SEND) {
+                // Check for file stream first — even text/* MIME types can be file shares
+                val streamUri = intent.parcelable<Uri>(Intent.EXTRA_STREAM)
+                if (streamUri != null) {
+                    notifyShareIntent(mapOf("files" to arrayOf(getFileInfo(streamUri)), "type" to "file"))
+                } else if (intent.type!!.startsWith("text/")) {
+                    // Pure text share (no file attachment)
                     notifyShareIntent(mapOf(
                         "text" to intent.getStringExtra(Intent.EXTRA_TEXT),
                         "type" to "text",
@@ -183,30 +188,20 @@ class ExpoShareIntentModule : Module() {
                             "title" to intent.getCharSequenceExtra(Intent.EXTRA_TITLE),
                         )
                     ))
-                } else if (intent.action == Intent.ACTION_VIEW) {
-                    notifyShareIntent(mapOf( "text" to intent.dataString, "type" to "text"))
                 } else {
-                    notifyError("Invalid action for text sharing: " + intent.action)
+                    notifyError("Unsupported ACTION_SEND with no stream and non-text type: ${intent.type}")
                 }
+            } else if (intent.action == Intent.ACTION_SEND_MULTIPLE) {
+                val uris = intent.parcelableArrayList<Uri>(Intent.EXTRA_STREAM)
+                if (uris != null) {
+                    notifyShareIntent(mapOf("files" to uris.map { getFileInfo(it) }, "type" to "file"))
+                } else {
+                    notifyError("empty uris array for file sharing: ${intent.action}")
+                }
+            } else if (intent.action == Intent.ACTION_VIEW) {
+                notifyShareIntent(mapOf("text" to intent.dataString, "type" to "text"))
             } else {
-                // files / medias
-                if (intent.action == Intent.ACTION_SEND) {
-                    val uri = intent.parcelable<Uri>(Intent.EXTRA_STREAM);
-                    if (uri != null) {
-                        notifyShareIntent(mapOf( "files" to arrayOf(getFileInfo(uri), "type" to "file")))
-                    } else {
-                        notifyError("empty uri for file sharing: " + intent.action)
-                    }
-                } else if (intent.action == Intent.ACTION_SEND_MULTIPLE) {
-                    val uris = intent.parcelableArrayList<Uri>(Intent.EXTRA_STREAM)
-                    if (uris != null) {
-                        notifyShareIntent(mapOf( "files" to uris.map { getFileInfo(it) }, "type" to "file"))
-                    } else {
-                        notifyError("empty uris array for file sharing: " + intent.action)
-                    }
-                } else {
-                    notifyError("Invalid action for file sharing: " + intent.action)
-                }
+                notifyError("Unsupported intent action: ${intent.action}")
             }
         }
 

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -63,52 +63,103 @@ class ExpoShareIntentModule : Module() {
                 notifyError("Cannot get resolver (getFileInfo)")
                 return mapOf(
                     "contentUri" to uri.toString(),
-                    "filePath" to instance?.getAbsolutePath(uri),
                 )
             }
-            val queryResult: Cursor = resolver.query(uri, null, null, null, null)!!
-            queryResult.moveToFirst()
-            val fileName = queryResult.getString(queryResult.getColumnIndex(OpenableColumns.DISPLAY_NAME))
-            val fileSize = queryResult.getString(queryResult.getColumnIndex(OpenableColumns.SIZE))
-            queryResult.close()
 
-            val mimeType = resolver.getType(uri)!!
-
-            var mediaWidth: String? = null;
-            var mediaHeight: String? = null;
-            var mediaDuration: String? = null;
-            if (mimeType.startsWith("image/")) {
-                val options = BitmapFactory.Options().apply {
-                    inJustDecodeBounds = true
+            try {
+                // Step 1: Read metadata from the content URI while permission is valid
+                var fileName: String? = null
+                var fileSize: String? = null
+                try {
+                    resolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE), null, null, null)?.use { cursor ->
+                        if (cursor.moveToFirst()) {
+                            val nameIdx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                            val sizeIdx = cursor.getColumnIndex(OpenableColumns.SIZE)
+                            if (nameIdx >= 0) fileName = cursor.getString(nameIdx)
+                            if (sizeIdx >= 0) fileSize = cursor.getString(sizeIdx)
+                        }
+                    }
+                } catch (e: SecurityException) {
+                    Log.w("ExpoShareIntent", "Cannot query metadata for $uri: ${e.message}")
                 }
-                BitmapFactory.decodeStream(resolver.openInputStream(uri), null, options)
-                mediaHeight = options.outHeight.toString()
-                mediaWidth = options.outWidth.toString()
-            }
-            if (mimeType.startsWith("video/")) {
-                val retriever = MediaMetadataRetriever()
-                retriever.setDataSource(instance?.getAbsolutePath(uri))
-                mediaWidth = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toInt().toString() ?: null
-                mediaHeight = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toInt().toString() ?: null
-                // Check orientation and flip size if required
-                val metaRotation = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)?.toInt() ?: 0;
-                if (metaRotation == 90 || metaRotation == 270) {
-                    mediaWidth = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toInt().toString() ?: null
-                    mediaHeight = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toInt().toString() ?: null
-                }
-                mediaDuration = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toInt().toString() ?: null
-            }
 
-            return mapOf(
-                    "contentUri" to uri.toString(),
-                    "filePath" to instance?.getAbsolutePath(uri),
-                    "fileName" to fileName,
-                    "fileSize" to fileSize,
-                    "mimeType" to mimeType,
-                    "width" to mediaWidth,
-                    "height" to mediaHeight,
-                    "duration" to mediaDuration
-            )
+                val mimeType = try {
+                    resolver.getType(uri)
+                } catch (e: SecurityException) {
+                    Log.w("ExpoShareIntent", "Cannot get MIME type for $uri: ${e.message}")
+                    null
+                }
+
+                // Step 2: Copy file to cache immediately (while URI permission is still valid)
+                val extension = if (fileName != null && fileName!!.contains(".")) {
+                    fileName!!.substringAfterLast(".")
+                } else {
+                    MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) ?: "bin"
+                }
+                val safeName = fileName ?: "shared_${Date().time}.$extension"
+                val targetFile = File(instance?.context?.cacheDir, safeName)
+
+                resolver.openInputStream(uri)?.use { input ->
+                    FileOutputStream(targetFile).use { output ->
+                        input.copyTo(output)
+                    }
+                } ?: run {
+                    notifyError("Cannot open input stream for $uri")
+                    return mapOf("contentUri" to uri.toString())
+                }
+
+                // Step 3: If we couldn't get size from metadata, use the copied file size
+                if (fileSize == null) {
+                    fileSize = targetFile.length().toString()
+                }
+
+                // Step 4: Read media dimensions from the LOCAL copy (no permission needed)
+                var mediaWidth: String? = null
+                var mediaHeight: String? = null
+                var mediaDuration: String? = null
+
+                if (mimeType?.startsWith("image/") == true) {
+                    val options = BitmapFactory.Options().apply {
+                        inJustDecodeBounds = true
+                    }
+                    BitmapFactory.decodeFile(targetFile.path, options)
+                    mediaHeight = options.outHeight.toString()
+                    mediaWidth = options.outWidth.toString()
+                }
+                if (mimeType?.startsWith("video/") == true) {
+                    try {
+                        val retriever = MediaMetadataRetriever()
+                        retriever.setDataSource(targetFile.path)
+                        mediaWidth = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+                        mediaHeight = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+                        val metaRotation = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)?.toIntOrNull() ?: 0
+                        if (metaRotation == 90 || metaRotation == 270) {
+                            val tmp = mediaWidth
+                            mediaWidth = mediaHeight
+                            mediaHeight = tmp
+                        }
+                        mediaDuration = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                        retriever.release()
+                    } catch (e: Exception) {
+                        Log.w("ExpoShareIntent", "Cannot read video metadata: ${e.message}")
+                    }
+                }
+
+                return mapOf(
+                        "contentUri" to uri.toString(),
+                        "filePath" to targetFile.path,
+                        "fileName" to (fileName ?: safeName),
+                        "fileSize" to fileSize,
+                        "mimeType" to mimeType,
+                        "width" to mediaWidth,
+                        "height" to mediaHeight,
+                        "duration" to mediaDuration
+                )
+            } catch (e: Exception) {
+                Log.e("ExpoShareIntent", "getFileInfo failed for $uri: ${e.message}", e)
+                notifyError("Cannot process shared file: ${e.message}")
+                return mapOf("contentUri" to uri.toString())
+            }
         }
 
         fun handleShareIntent(intent: Intent) {


### PR DESCRIPTION
## Summary

Fixes two Android bugs in `handleShareIntent` / `getFileInfo`:

### Bug 1: SecurityException on shared files (fixes #175)

`getFileInfo` calls `resolver.query(uri)` directly on the content URI. On Android 12+, content providers like Google Photos (`MediaContentProvider`) and Downloads (`DownloadStorageProvider`) are not exported. The temporary URI permission granted by `FLAG_GRANT_READ_URI_PERMISSION` can expire before the async `getShareIntent` call reaches the native module, causing:

```
java.lang.SecurityException: Permission Denial: opening provider
com.google.android.apps.photos.contentprovider.impl.MediaContentProvider
... that is not exported from UID 10170
```

**Fix:** Copy the file to app cache via `openInputStream` immediately (while URI permission is valid), then read metadata from the local copy. Metadata query and MIME type resolution are wrapped in try-catch so a single provider failure doesn't crash the entire share flow.

### Bug 2: Files with `text/*` MIME types silently dropped

`handleShareIntent` checks `intent.type.startsWith("text/plain")` before checking for `EXTRA_STREAM`. When a file with a `text/*` MIME type (`.txt`, `.csv`, `.html`, etc.) is shared from a file manager, the MIME type is `text/plain` (or another `text/*` variant) but the file is delivered via `EXTRA_STREAM` (not `EXTRA_TEXT`). The code enters the text branch, reads `EXTRA_TEXT` (null), and the share is silently lost.

**Fix:** Check for `EXTRA_STREAM` first in `ACTION_SEND`. If a stream URI exists, always treat it as a file regardless of MIME type. Text handling is only used when there is no stream attachment.

## Testing

Tested with:
- Share image from Google Photos → ✅ file received (was SecurityException)
- Share PDF from Downloads → ✅ file received (was SecurityException)
- Share .txt file from file manager → ✅ file received (was silently dropped)
- Share plain text from browser → ✅ text received (unchanged)
- Share multiple images → ✅ files received (unchanged)