### PR TITLE
fix: preserve existing iOS app groups

### DIFF
--- a/plugin/src/ios/withIosAppEntitlements.ts
+++ b/plugin/src/ios/withIosAppEntitlements.ts
@@ -1,17 +1,20 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.withAppEntitlements = void 0;
-const config_plugins_1 = require("@expo/config-plugins");
-const constants_1 = require("./constants");
-const withAppEntitlements = (config, parameters) => {
-    return (0, config_plugins_1.withEntitlementsPlist)(config, async (config) => {
-      const appIdentifier = config.ios?.bundleIdentifier;
-      const existing = config.modResults["com.apple.security.application-groups"] ?? [];
-      config.modResults["com.apple.security.application-groups"] = [
-        (0, constants_1.getAppGroup)(appIdentifier, parameters),
-        ...existing,
-      ];
-      return config;
-    });
+import { ConfigPlugin, withEntitlementsPlist } from "@expo/config-plugins";
+
+import { getAppGroup } from "./constants";
+import { Parameters } from "../types";
+
+export const withAppEntitlements: ConfigPlugin<Parameters> = (
+  config,
+  parameters,
+) => {
+  return withEntitlementsPlist(config, async (config) => {
+    const appIdentifier = config.ios?.bundleIdentifier!;
+    const existing =
+      config.modResults["com.apple.security.application-groups"] ?? [];
+    config.modResults["com.apple.security.application-groups"] = [
+      getAppGroup(appIdentifier, parameters),
+      ...existing,
+    ];
+    return config;
+  });
 };
-exports.withAppEntitlements = withAppEntitlements;

--- a/plugin/src/ios/withIosAppEntitlements.ts
+++ b/plugin/src/ios/withIosAppEntitlements.ts
@@ -9,11 +9,12 @@ export const withAppEntitlements: ConfigPlugin<Parameters> = (
 ) => {
   return withEntitlementsPlist(config, async (config) => {
     const appIdentifier = config.ios?.bundleIdentifier!;
-    const existing =
-      config.modResults["com.apple.security.application-groups"] ?? [];
+    const existing = config.modResults[
+      "com.apple.security.application-groups"
+    ];
     config.modResults["com.apple.security.application-groups"] = [
       getAppGroup(appIdentifier, parameters),
-      ...existing,
+      ...(Array.isArray(existing) ? existing : []),
     ];
     return config;
   });

--- a/plugin/src/ios/withIosAppEntitlements.ts
+++ b/plugin/src/ios/withIosAppEntitlements.ts
@@ -1,17 +1,17 @@
-import { ConfigPlugin, withEntitlementsPlist } from "@expo/config-plugins";
-
-import { getAppGroup } from "./constants";
-import { Parameters } from "../types";
-
-export const withAppEntitlements: ConfigPlugin<Parameters> = (
-  config,
-  parameters,
-) => {
-  return withEntitlementsPlist(config, async (config) => {
-    const appIdentifier = config.ios?.bundleIdentifier!;
-    config.modResults["com.apple.security.application-groups"] = [
-      getAppGroup(appIdentifier, parameters),
-    ];
-    return config;
-  });
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withAppEntitlements = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const constants_1 = require("./constants");
+const withAppEntitlements = (config, parameters) => {
+    return (0, config_plugins_1.withEntitlementsPlist)(config, async (config) => {
+      const appIdentifier = config.ios?.bundleIdentifier;
+      const existing = config.modResults["com.apple.security.application-groups"] ?? [];
+      config.modResults["com.apple.security.application-groups"] = [
+        (0, constants_1.getAppGroup)(appIdentifier, parameters),
+        ...existing,
+      ];
+      return config;
+    });
 };
+exports.withAppEntitlements = withAppEntitlements;


### PR DESCRIPTION
This PR updates the iOS entitlements config plugin so it preserves existing com.apple.security.application-groups values instead of replacing them.

The plugin now prepends the Expo Share Intent app group while keeping any app groups already present in the app entitlements.

Follow-up correction: restored plugin/src/ios/withIosAppEntitlements.ts as TypeScript source after the previous commit accidentally wrote compiled CommonJS output into the .ts file.