### PR TITLE
fix(ios): resolve "Cycle inside <app>" build error when embedding the share extension

### DIFF
--- a/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
+++ b/plugin/src/ios/withIosShareExtensionXcodeTarget.ts
@@ -47,6 +47,61 @@ function getMainAppDevelopmentTeam(pbx: any): string | null {
   return null;
 }
 
+//───────────────────────────────────────────────────────────────────────────
+// Helper: move the host app's "Embed App Extensions" phase ahead of its
+// run-script build phases to avoid an Xcode build cycle.
+//
+// `addTarget()` appends the "Embed App Extensions" copy-files phase (which writes
+// `<app>.app/PlugIns/<ext>.appex`) to the END of the host target's build phases.
+// That places it AFTER run-script phases such as expo-dev-launcher's
+// "[Expo Dev Launcher] Strip Local Network Keys for Release", which declares the
+// app's Info.plist (inside the .app bundle) as an input and no outputs. Xcode's
+// build system then needs the whole bundle assembled before that script can run,
+// yet the embed phase that finishes assembling it runs later — an unbreakable
+// cycle, and the build fails with:
+//   "Cycle inside <app>; building could produce unreliable results."
+//
+// The embed phase only depends on the extension target's product (an implicit
+// target dependency), so it is safe to run earlier. Moving it to just after the
+// host target's Resources phase makes the dependency one-directional and resolves
+// the cycle. No-op if the phase is already positioned before the run scripts.
+//───────────────────────────────────────────────────────────────────────────
+function moveEmbedAppExtensionsPhaseBeforeScripts(pbx: any): void {
+  const objects = pbx.hash.project.objects;
+  const nativeTargets = objects.PBXNativeTarget || {};
+  const copyPhases = objects.PBXCopyFilesBuildPhase || {};
+  const resourcePhases = objects.PBXResourcesBuildPhase || {};
+
+  for (const key of Object.keys(nativeTargets)) {
+    if (key.endsWith("_comment")) continue;
+    const target = nativeTargets[key];
+    if (
+      !target ||
+      typeof target !== "object" ||
+      !String(target.productType || "").includes("product-type.application")
+    ) {
+      continue;
+    }
+
+    const phases = target.buildPhases || [];
+    // "Embed App Extensions" is a copy-files phase whose destination is PlugIns
+    // (dstSubfolderSpec 13).
+    const embedIndex = phases.findIndex((bp: any) => {
+      const phase = copyPhases[bp.value];
+      return phase && String(phase.dstSubfolderSpec) === "13";
+    });
+    const resourceIndex = phases.findIndex(
+      (bp: any) => resourcePhases[bp.value],
+    );
+    if (embedIndex < 0 || resourceIndex < 0) continue;
+    if (embedIndex === resourceIndex + 1) continue; // already early enough
+
+    const [embed] = phases.splice(embedIndex, 1);
+    // embedIndex > resourceIndex, so resourceIndex is unaffected by the splice.
+    phases.splice(resourceIndex + 1, 0, embed);
+  }
+}
+
 export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (
   config,
   parameters,
@@ -218,6 +273,11 @@ export const withShareExtensionXcodeTarget: ConfigPlugin<Parameters> = (
       const shareTarget = pbxProject.pbxTargetByName(extensionName);
       pbxProject.addTargetAttribute("DevelopmentTeam", devTeam, shareTarget);
     }
+
+    /* ------------------------------------------------------------------ */
+    /* 7. Avoid the "Embed App Extensions" ↔ run-script build cycle       */
+    /* ------------------------------------------------------------------ */
+    moveEmbedAppExtensionsPhaseBeforeScripts(pbxProject);
 
     console.log(
       `[expo-share-intent] Successfully created ${extensionName} target with files`,


### PR DESCRIPTION
**Summary**

Embedding the iOS share extension currently breaks the build with:

```
error: Cycle inside <app>; building could produce unreliable results.
```

`xcodebuild` exits 65 and the app never links. It reproduces on a stock Expo
dev-client app as soon as `expo-share-intent` is added (no special config).

**Root cause**

When the plugin creates the extension target, `node-xcode`'s `addTarget()`
appends the *Embed App Extensions* copy-files phase — the one that writes
`<app>.app/PlugIns/<ext>.appex` — to the **end** of the host app target's build
phases.

That places it **after** run-script phases that other Expo modules add to the
same target, in particular expo-dev-launcher's
`[Expo Dev Launcher] Strip Local Network Keys for Release`. That script declares
the app's `Info.plist` (which lives *inside* the `.app` bundle) as an input and
declares **no outputs**, so Xcode's build system treats it as depending on the
whole bundle being assembled. But the embed phase that finishes assembling the
bundle now runs *after* it — so the two phases can't be ordered, and Xcode
reports a cycle.

The relevant part of the cycle trace:

```
→ Target 'App' has copy command from '…/ShareExtension.appex'
    to '…/App.app/PlugIns/ShareExtension.appex'
○ That command depends on command in Target 'App':
    script phase "[Expo Dev Launcher] Strip Local Network Keys for Release"
○ Target 'App' has process command with output '…/App.app/Info.plist'
○ Target 'App' has copy command from '…/ShareExtension.appex'
    to '…/App.app/PlugIns/ShareExtension.appex'
```

**Fix**

Move the *Embed App Extensions* copy-files phase to run just after the host
target's `Resources` phase, i.e. ahead of the run-script phases. The embed phase
only depends on the extension target's product (an implicit target dependency
created by `addTarget`), so it is safe to run earlier; doing so makes the
dependency one-directional and the cycle disappears.

The change is contained to `withShareExtensionXcodeTarget`: it only reorders an
existing phase (no add/remove), and it's a no-op when the phase is already ahead
of the run scripts, so it's safe to re-run on subsequent prebuilds.

**Tested**

- Expo SDK 56, React Native 0.85, `expo-dev-client`, Xcode 26.5, iOS Simulator.
- Before: `xcodebuild` fails with `Cycle inside <app>` (exit 65).
- After: with the embed phase reordered ahead of the dev-launcher strip script,
  the same project builds — `** BUILD SUCCEEDED **`.
- `tsc` and `prettier` pass on the changed file.

**Todo**

- [x] Fix the build cycle
- [x] Typecheck + format the change

**Issue**

None yet — happy to open one to track this if you'd prefer.

---

_Unrelated to this PR, but noticed while debugging: the extension's
`PrivacyInfo.xcprivacy` shares a basename with the host app's own
`PrivacyInfo.xcprivacy`, and node-xcode appears to collide them so the app target
ends up referencing the extension's manifest. It doesn't break the build, so I've
left it out here — glad to send a separate PR if it's worth fixing._
