### PR TITLE
fix: android detect .txt file shares in text/plain intents

### DIFF
--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -125,13 +125,26 @@ class ExpoShareIntentModule : Module() {
             if (intent.type!!.startsWith("text/plain")) {
                 // text / urls
                 if (intent.action == Intent.ACTION_SEND) {
-                    notifyShareIntent(mapOf(
-                        "text" to intent.getStringExtra(Intent.EXTRA_TEXT),
-                        "type" to "text",
-                        "meta" to mapOf(
-                            "title" to intent.getCharSequenceExtra(Intent.EXTRA_TITLE),
-                        )
-                    ))
+                    // Check if this is a file share (e.g., .txt file) rather than a text selection
+                    val streamUri = intent.parcelable<Uri>(Intent.EXTRA_STREAM)
+                    if (streamUri != null) {
+                        notifyShareIntent(mapOf("files" to arrayOf(getFileInfo(streamUri)), "type" to "file"))
+                    } else {
+                        notifyShareIntent(mapOf(
+                            "text" to intent.getStringExtra(Intent.EXTRA_TEXT),
+                            "type" to "text",
+                            "meta" to mapOf(
+                                "title" to intent.getCharSequenceExtra(Intent.EXTRA_TITLE),
+                            )
+                        ))
+                    }
+                } else if (intent.action == Intent.ACTION_SEND_MULTIPLE) {
+                    val uris = intent.parcelableArrayList<Uri>(Intent.EXTRA_STREAM)
+                    if (uris != null) {
+                        notifyShareIntent(mapOf("files" to uris.map { getFileInfo(it) }, "type" to "file"))
+                    } else {
+                        notifyError("empty uris array for text file sharing: " + intent.action)
+                    }
                 } else if (intent.action == Intent.ACTION_VIEW) {
                     notifyShareIntent(mapOf( "text" to intent.dataString, "type" to "text"))
                 } else {


### PR DESCRIPTION
**Summary**

Issue: sharing .txt files on Android fails.

sharing a text selection (e.g highlighting text on a webpage and tapping share works correctly)

in ExpoShareIntentModule.kt, handleShareIntent routes intents based on intent.type. The problem is that on Android both .txt files and text selections show as text/plain, but behave differently.

text selection has the content in Intent.EXTRA_TEXT 
while for a txt file (or multiple) EXTRA_TEXT is null, and it contains a URI for the content in Intent.EXTRA_STREAM (or a list of URIs for multiple txt files)

txt files are currently classified into that first branch which only looks for extra_text which they don't have.

**the fix** is to check whether extra_stream is present, if so => the intent is a file share. if extra_stream is absent, treat it as a text selection.

also for handling multiple txt files, Android uses a different action when the user selects multiple files. the text/plain branch has no handler for this action. it falls through to notifyError() and gets dropped.

we could add the same array based extra_stream handling that is used in the else (file/media) branch.