### PR TITLE
fix(android): prevent path traversal from shared file _display_name (…

### DIFF
--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentModule.kt
@@ -301,8 +301,14 @@ class ExpoShareIntentModule : Module() {
                     val columnIndex = cursor.getColumnIndexOrThrow(column)
                     val fileName = cursor.getString(columnIndex)
                     Log.i("FileDirectory", "File name: $fileName")
-                    targetFile = File(context.cacheDir, fileName)
-                }
+                    val safeName = fileName?.let { File(it).name }.orEmpty()
+                    if (safeName.isNotEmpty()) {
+                        val candidate = File(context.cacheDir, safeName)
+                        val cacheRoot = context.cacheDir.canonicalPath + File.separator
+                        if (candidate.canonicalPath.startsWith(cacheRoot)) {
+                            targetFile = candidate
+                        }
+                    }                }
             } finally {
                 cursor?.close()
             }


### PR DESCRIPTION
## Summary
`getDataColumn` (`ExpoShareIntentModule.kt`) copies inbound shared files into `cacheDir` using the `_display_name` reported by the *sending* app's ContentProvider as the destination filename, unsanitized:

```kotlin
targetFile = File(context.cacheDir, fileName)
```

`_display_name` is fully attacker-controlled. A malicious app can return `../databases/RKStorage` (or any `../` value), so the copy escapes `cacheDir` and writes attacker-controlled bytes to an arbitrary path under the host app's private data dir- path traversal / "Dirty Stream" (CWE-22). No permissions are required by the sender, and a single `ACTION_SEND` (any non-`text/plain` type carrying `EXTRA_STREAM`) suffices. All released versions (2.0.0–8.0.0) are affected.

## Fix
Reduce the provider-supplied name to its basename and verify the resolved file stays inside `cacheDir`; otherwise leave `targetFile` null so the existing generated `${prefix}_${Date().time}.$type` name is used. Behavior is unchanged for legitimate shares - only traversal is neutralized. No new imports (`File`, `.canonicalPath`, `File.separator` already in use).

## Testing
Malicious ContentProvider returns `_display_name = ../databases/RKStorage`, sender fires `Intent(ACTION_SEND).setType("text/html").putExtra(EXTRA_STREAM, evilUri)`.
- Before: file written to `/data/data/<pkg>/databases/RKStorage` (outside cache).
- After: written as `cacheDir/RKStorage` (basename) or the generated fallback; no escape.