### PR TITLE
fix(ios): don't duplicate appExtensions entry when it exists at index 0

### DIFF
--- a/plugin/src/ios/withIosShareExtensionConfig.ts
+++ b/plugin/src/ios/withIosShareExtensionConfig.ts
@@ -21,7 +21,7 @@ export const withShareExtensionConfig: ConfigPlugin<Parameters> = (
   // When disabled this function no longer alters the config object passed to it
   // It only returns the original config to satisfy any calling conventions
   if (!parameters.disableExperimental) {
-    let extConfigIndex = null;
+    let extConfigIndex: number | null = null;
     config.extra?.eas?.build?.experimental?.ios?.appExtensions?.forEach(
       (ext: any, index: number) => {
         ext.targetName === extName && (extConfigIndex = index);
@@ -32,7 +32,7 @@ export const withShareExtensionConfig: ConfigPlugin<Parameters> = (
       config.extra = {};
     }
 
-    if (!extConfigIndex) {
+    if (extConfigIndex === null) {
       if (!config.extra.eas) {
         config.extra.eas = {};
       }


### PR DESCRIPTION
**Summary**

`withShareExtensionConfig` duplicates the ShareExtension `appExtensions` entry whenever the entry already exists at **index 0** of `extra.eas.build.experimental.ios.appExtensions`, which makes `withCompatibilityChecker` throw:

```
[expo-share-intent] Incompatibility found, you have more than one appExtensions for "ShareExtension" (2). ...
```

and crashes `expo config --json` (exit 1, swallowed by eas-cli — users only see `config --json exited with non-zero code: 1` from `eas project:init` / `eas update` / `eas build`).

Root cause is a falsy-zero guard:

```ts
let extConfigIndex = null;
appExtensions?.forEach((ext, index) => {
  ext.targetName === extName && (extConfigIndex = index);
});
if (!extConfigIndex) {   // !0 === true → index 0 treated as "not found"
  appExtensions.push({ targetName: extName, ... });
}
```

How the entry ends up on disk at index 0: the plugin normally adds it only in-memory, but when `eas project:init` or `eas update` has to modify app.json (writing `extra.eas.projectId` or `updates.url`), eas-cli serializes the **evaluated** config back to disk — persisting the plugin-added entry at index 0. Every subsequent config evaluation then hits the guard and pushes a duplicate. Any CI flow running `eas project:init`/`eas update` against a clean checkout fails 100% deterministically.

This PR changes the guard to `extConfigIndex === null` (and types the variable `number | null`), so an existing entry at index 0 is found and reused — count stays 1 and the compatibility checker passes.

Verified against a real-world failing app (Expo SDK 54, plugin 5.1.1): `eas project:init --force --non-interactive` followed by a config re-read fails on the unpatched plugin and exits 0 with this fix. Note: #109 previously fixed the adjacent post-push index assignment (`extConfigIndex = 0` → `length - 1`) but left this guard untouched.

**Todo**

- [x] Fix truthiness check in `withShareExtensionConfig` (`!extConfigIndex` → `extConfigIndex === null`)
- [x] `yarn build:plugin` passes

**Issue**

Fixes #198
