### PR TITLE
fix(android): don't re-deliver stale share intent when Activity is recreated

### DIFF
--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentApplicationLifecycleListener.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentApplicationLifecycleListener.kt
@@ -1,0 +1,29 @@
+package expo.modules.shareintent
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import expo.modules.core.interfaces.ApplicationLifecycleListener
+
+class ExpoShareIntentApplicationLifecycleListener : ApplicationLifecycleListener {
+    override fun onCreate(application: Application) {
+        // onActivityPreCreated (API 29+) receives the framework's real savedInstanceState
+        // before the Activity's own onCreate runs. ReactActivityLifecycleListener.onCreate
+        // can't be used for this: RN/Expo MainActivity templates call super.onCreate(null),
+        // so the bundle is always null there. Below API 29 this hook never fires and
+        // behavior is unchanged.
+        application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+                ExpoShareIntentSingleton.isRecreation = savedInstanceState != null
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+            override fun onActivityStarted(activity: Activity) {}
+            override fun onActivityResumed(activity: Activity) {}
+            override fun onActivityPaused(activity: Activity) {}
+            override fun onActivityStopped(activity: Activity) {}
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+            override fun onActivityDestroyed(activity: Activity) {}
+        })
+    }
+}

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentPackage.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentPackage.kt
@@ -1,11 +1,16 @@
 package expo.modules.shareintent
 
 import android.content.Context
+import expo.modules.core.interfaces.ApplicationLifecycleListener
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
 class ExpoShareIntentPackage : Package {
   override fun createReactActivityLifecycleListeners(activityContext: Context): List<ReactActivityLifecycleListener> {
     return listOf(ExpoShareIntentReactActivityLifecycleListener(activityContext))
+  }
+
+  override fun createApplicationLifecycleListeners(context: Context): List<ApplicationLifecycleListener> {
+    return listOf(ExpoShareIntentApplicationLifecycleListener())
   }
 }

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentReactActivityLifecycleListener.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentReactActivityLifecycleListener.kt
@@ -13,9 +13,13 @@ import expo.modules.core.interfaces.ReactActivityLifecycleListener
 class ExpoShareIntentReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
 
     override fun onCreate(activity: Activity?, savedInstanceState: Bundle?) {
-        // only store when the new intent is not empty
-        if (activity?.intent?.type != null) {
-            ExpoShareIntentSingleton.intent = activity?.intent
+        // only store when the new intent is not empty AND this is a fresh launch.
+        // When savedInstanceState != null the Activity is being recreated (process
+        // killed with the task retained, or a configuration change): the system
+        // re-supplies the original task-root intent, so treating it as a new share
+        // would re-deliver a share that was already consumed in a previous session.
+        if (savedInstanceState == null && activity?.intent?.type != null) {
+            ExpoShareIntentSingleton.intent = activity.intent
             ExpoShareIntentSingleton.isPending = true
         }
     }

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentReactActivityLifecycleListener.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentReactActivityLifecycleListener.kt
@@ -13,12 +13,13 @@ import expo.modules.core.interfaces.ReactActivityLifecycleListener
 class ExpoShareIntentReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
 
     override fun onCreate(activity: Activity?, savedInstanceState: Bundle?) {
-        // only store when the new intent is not empty AND this is a fresh launch.
-        // When savedInstanceState != null the Activity is being recreated (process
-        // killed with the task retained, or a configuration change): the system
-        // re-supplies the original task-root intent, so treating it as a new share
-        // would re-deliver a share that was already consumed in a previous session.
-        if (savedInstanceState == null && activity?.intent?.type != null) {
+        // only store when the intent is not empty AND this is a fresh launch. On a system
+        // recreation (process killed with the task retained under launchMode=singleTask)
+        // the original task-root share intent is re-supplied, and capturing it again would
+        // re-deliver an already-consumed share on every reopen. Recreation is detected via
+        // onActivityPreCreated (see ExpoShareIntentApplicationLifecycleListener) — the
+        // savedInstanceState parameter here is always null in RN/Expo apps and can't be used.
+        if (!ExpoShareIntentSingleton.isRecreation && activity?.intent?.type != null) {
             ExpoShareIntentSingleton.intent = activity.intent
             ExpoShareIntentSingleton.isPending = true
         }

--- a/android/src/main/java/expo/modules/shareintent/ExpoShareIntentSingleton.kt
+++ b/android/src/main/java/expo/modules/shareintent/ExpoShareIntentSingleton.kt
@@ -12,4 +12,9 @@ object ExpoShareIntentSingleton : SingletonModule {
   // members to store the initial launch intent
   var intent: Intent? = null
   var isPending: Boolean = false
+
+  // true while the Activity currently being created is a system recreation
+  // (process death with task retained, config change) rather than a fresh launch.
+  // Set from onActivityPreCreated; false below API 29.
+  var isRecreation: Boolean = false
 }


### PR DESCRIPTION
## Problem

On Android (`launchMode=singleTask`, the plugin default), a share that cold-starts the app becomes the task-root intent. If the OS later kills the process while the task stays in recents, reopening the app recreates the Activity with that original share intent, and `ExpoShareIntentReactActivityLifecycleListener.onCreate` re-captures it — the app re-processes the same stale share on **every reopen** until the task is swiped away. `clearShareIntent` can't prevent it: the singleton is rebuilt from `activity.intent` on the next launch.

## Reproduction (confirmed on a physical Pixel, production build)

1. Swipe the app away in recents
2. Share content into the app (cold start) → processed normally
3. Press home, then `adb shell am kill <package>`
4. Reopen from the launcher icon → the old share is delivered again. Repeats every kill/reopen cycle; swiping the task away stops it.

## Fix

Skip capturing the intent when the Activity is being **recreated** rather than freshly launched.

Recreation can't be detected from the listener's own `savedInstanceState`: RN/Expo `MainActivity` templates call `super.onCreate(null)` ([required by react-native-screens](https://github.com/software-mansion/react-native-screens/issues/2049)), so that parameter is always null by the time it reaches `ReactActivityLifecycleListener.onCreate`. Instead:

- An `ApplicationLifecycleListener` registers `Application.ActivityLifecycleCallbacks` and uses **`onActivityPreCreated`** (API 29+), which the framework dispatches with the _real_ `savedInstanceState` before `MainActivity.onCreate` can drop it. It stores an `isRecreation` flag in the singleton.
- The activity lifecycle listener consults that flag before capturing `activity.intent`.
- Below API 29 the hook never fires, `isRecreation` stays false, and behavior is unchanged.

Genuine shares are unaffected: they arrive either as a fresh launch (no saved state → flag false) or via `onNewIntent` while the app is running — both paths untouched.

Known limitation: after a manual force-stop, relaunch from recents redelivers the root intent with no saved state to key on; that narrow path stays as-is.

**Disclaimer:** the reproduction above is device-confirmed, but this patch itself hasn't been device-tested yet.
